### PR TITLE
feat: Added support for providing path to ca_cert for acp_ocp_install role

### DIFF
--- a/changelogs/fragments/aap_ocp_install-ca-cert.yml
+++ b/changelogs/fragments/aap_ocp_install-ca-cert.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - >-
+    aap_ocp_install - add support for supplying path to CA certificate

--- a/roles/aap_ocp_install/README.md
+++ b/roles/aap_ocp_install/README.md
@@ -51,6 +51,7 @@ The tables below list user-facing variables and nested keys.
 | `password`       | Yes\*    |         | Password for cluster login.                                     |
 | `api_key`        | Yes\*    |         | API token (do not set `username` / `password` when using this). |
 | `validate_certs` | No       |         | Whether to verify TLS. Valid values: `true`, `false`.           |
+| `ca_cert`        | No       |         | Path to a CA certificate to verify the OpenShift API server.    |
 
 \* Either `api_key`, or both `username` and `password`, must be set.
 

--- a/roles/aap_ocp_install/defaults/main.yml
+++ b/roles/aap_ocp_install/defaults/main.yml
@@ -6,6 +6,7 @@
 #   password:
 #   api_key:
 #   validate_certs:
+#   ca_cert:
 
 # Namespace to install into
 # aap_ocp_install_namespace:

--- a/roles/aap_ocp_install/tasks/consolelinks.yml
+++ b/roles/aap_ocp_install/tasks/consolelinks.yml
@@ -10,6 +10,7 @@
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     state: present
     resource_definition: "{{ lookup('ansible.builtin.template', 'controller/consolelink.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_controller['consolelink_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
@@ -25,6 +26,7 @@
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     state: present
     resource_definition: "{{ lookup('ansible.builtin.template', 'hub/consolelink.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_hub['consolelink_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
@@ -40,6 +42,7 @@
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     state: present
     resource_definition: "{{ lookup('ansible.builtin.template', 'eda/consolelink.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_eda['consolelink_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
@@ -55,6 +58,7 @@
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     state: present
     resource_definition: "{{ lookup('ansible.builtin.template', 'platform/consolelink.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_platform['consolelink_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true

--- a/roles/aap_ocp_install/tasks/finalization.yml
+++ b/roles/aap_ocp_install/tasks/finalization.yml
@@ -6,6 +6,7 @@
   redhat.openshift.openshift_auth:
     host: "{{ aap_ocp_install_connection['host'] | mandatory }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     state: absent
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
   changed_when: false

--- a/roles/aap_ocp_install/tasks/initialization.yml
+++ b/roles/aap_ocp_install/tasks/initialization.yml
@@ -7,6 +7,7 @@
     username: "{{ aap_ocp_install_connection['username'] | mandatory }}"
     password: "{{ aap_ocp_install_connection['password'] | mandatory }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
   register: __aap_ocp_install_auth_results
 
 - name: initialization | Set authentication for provided API key
@@ -18,6 +19,7 @@
         host: "{{ aap_ocp_install_connection['host'] | mandatory }}"
         api_key: "{{ aap_ocp_install_connection['api_key'] | mandatory }}"
         validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+        ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
 
 - name: initialization | Include validate-connection tasks
   ansible.builtin.include_tasks:
@@ -35,6 +37,7 @@
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     state: present
     resource_definition: "{{ lookup('ansible.builtin.template', 'namespace.yaml.j2', template_vars=ns_vars) | from_yaml | ansible.builtin.combine(aap_ocp_install_namespace_manifest_overrides | default({}), recursive=true) }}"
     apply: true

--- a/roles/aap_ocp_install/tasks/install-controller.yml
+++ b/roles/aap_ocp_install/tasks/install-controller.yml
@@ -6,6 +6,7 @@
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     state: present
     resource_definition: "{{ lookup('ansible.builtin.template', 'namespace.yaml.j2', template_vars=ns_vars) | from_yaml | ansible.builtin.combine(aap_ocp_install_controller['namespace_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
@@ -18,6 +19,7 @@
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     state: present
     resource_definition: "{{ lookup('template', 'controller/instance.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_controller['controller_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
@@ -27,6 +29,7 @@
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     kind: Route
     name: "{{ aap_ocp_install_controller['instance_name'] | mandatory }}"
     api_version: route.openshift.io/v1
@@ -45,6 +48,7 @@
   ansible.builtin.uri:
     url: "{{ aap_ocp_install_controller_route }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_path: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     method: GET
     status_code:
       - 200

--- a/roles/aap_ocp_install/tasks/install-eda.yml
+++ b/roles/aap_ocp_install/tasks/install-eda.yml
@@ -6,6 +6,7 @@
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     state: present
     resource_definition: "{{ lookup('ansible.builtin.template', 'namespace.yaml.j2', template_vars=ns_vars) | from_yaml | ansible.builtin.combine(aap_ocp_install_eda['namespace_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
@@ -18,6 +19,7 @@
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     state: present
     resource_definition: "{{ lookup('template', 'eda/instance.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_eda['eda_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
@@ -27,6 +29,7 @@
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     kind: Route
     name: "{{ aap_ocp_install_eda['instance_name'] | mandatory }}"
     api_version: route.openshift.io/v1
@@ -45,6 +48,7 @@
   ansible.builtin.uri:
     url: "{{ aap_ocp_install_eda_route }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_path: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     method: GET
     status_code:
       - 200

--- a/roles/aap_ocp_install/tasks/install-hub.yml
+++ b/roles/aap_ocp_install/tasks/install-hub.yml
@@ -6,6 +6,7 @@
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     state: present
     resource_definition: "{{ lookup('ansible.builtin.template', 'namespace.yaml.j2', template_vars=ns_vars) | from_yaml | ansible.builtin.combine(aap_ocp_install_hub['namespace_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
@@ -18,6 +19,7 @@
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     state: present
     resource_definition: "{{ lookup('template', 'hub/instance.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_hub['hub_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
@@ -27,6 +29,7 @@
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     kind: Route
     name: "{{ aap_ocp_install_hub['instance_name'] | mandatory }}"
     api_version: route.openshift.io/v1
@@ -45,6 +48,7 @@
   ansible.builtin.uri:
     url: "{{ aap_ocp_install_hub_route }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_path: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     method: GET
     status_code:
       - 200

--- a/roles/aap_ocp_install/tasks/install-operator.yml
+++ b/roles/aap_ocp_install/tasks/install-operator.yml
@@ -6,6 +6,7 @@
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     state: present
     resource_definition: "{{ lookup('template', 'operator/operatorgroup.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_operator['operatorgroup_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
@@ -15,6 +16,7 @@
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     state: present
     resource_definition: "{{ lookup('template', 'operator/subscription.yaml.j2') | from_yaml | ansible.builtin.combine(aap_ocp_install_operator['subscription_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
@@ -24,6 +26,7 @@
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     kind: Subscription
     name: ansible-automation-platform-operator
     api_version: operators.coreos.com/v1alpha1
@@ -45,6 +48,7 @@
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     definition:
       kind: InstallPlan
       apiVersion: operators.coreos.com/v1alpha1
@@ -59,6 +63,7 @@
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     kind: Subscription
     name: ansible-automation-platform-operator
     api_version: operators.coreos.com/v1alpha1
@@ -75,6 +80,7 @@
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     kind: ClusterServiceVersion
     name: "{{ __aap_ocp_install_sub_approved_result.resources[0].status.currentCSV }}"
     api_version: operators.coreos.com/v1alpha1

--- a/roles/aap_ocp_install/tasks/install-platform.yml
+++ b/roles/aap_ocp_install/tasks/install-platform.yml
@@ -6,6 +6,7 @@
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     state: present
     resource_definition: "{{ lookup('ansible.builtin.template', 'namespace.yaml.j2', template_vars=ns_vars) | from_yaml | ansible.builtin.combine(aap_ocp_install_platform['namespace_manifest_overrides'] | default({}), recursive=true) }}"
     apply: true
@@ -22,6 +23,7 @@
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     state: present
     resource_definition: "{{ __aap_ocp_install_platform_cr }}"
     apply: true
@@ -31,6 +33,7 @@
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     kind: Route
     name: "{{ aap_ocp_install_platform['instance_name'] | mandatory }}"
     api_version: route.openshift.io/v1
@@ -49,6 +52,7 @@
   ansible.builtin.uri:
     url: "{{ aap_ocp_install_platform_route }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_path: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     method: GET
     status_code:
       - 200
@@ -70,6 +74,7 @@
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     kind: Route
     name: "{{ aap_ocp_install_platform['instance_name'] | mandatory }}-controller"
     api_version: route.openshift.io/v1
@@ -98,6 +103,7 @@
   ansible.builtin.uri:
     url: "{{ aap_ocp_install_controller_route }}/api"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_path: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     method: GET
     status_code:
       - 200
@@ -118,6 +124,7 @@
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     kind: Route
     name: "{{ aap_ocp_install_platform['instance_name'] | mandatory }}-eda"
     api_version: route.openshift.io/v1
@@ -146,6 +153,7 @@
   ansible.builtin.uri:
     url: "{{ aap_ocp_install_eda_route }}/api"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_path: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     method: GET
     status_code:
       - 200
@@ -166,6 +174,7 @@
     host: "{{ __aap_ocp_install_auth_results['openshift_auth']['host'] }}"
     api_key: "{{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_cert: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     kind: Route
     name: "{{ aap_ocp_install_platform['instance_name'] | mandatory }}-hub"
     api_version: route.openshift.io/v1
@@ -194,6 +203,7 @@
   ansible.builtin.uri:
     url: "{{ aap_ocp_install_hub_route }}/api/galaxy/pulp/api/v3/"
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_path: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     method: GET
     status_code:
       - 200

--- a/roles/aap_ocp_install/tasks/validate-connection.yml
+++ b/roles/aap_ocp_install/tasks/validate-connection.yml
@@ -5,6 +5,7 @@
     url: "{{  __aap_ocp_install_auth_results['openshift_auth']['host'] }}/version"
     method: GET
     validate_certs: "{{ aap_ocp_install_connection['validate_certs'] | default(omit) }}"
+    ca_path: "{{ aap_ocp_install_connection['ca_cert'] | default(omit) }}"
     headers:
       Authorization: Bearer {{ __aap_ocp_install_auth_results['openshift_auth']['api_key'] }}
 


### PR DESCRIPTION
# What does this PR do?

Adds support for supplying the path of a CA certificate when connecting to OpenShift

# How should this be tested?

Include the `ca_cert` with the location of the OpenShift CA certificate as part of the `aap_ocp_install_connection` property
for the `aap_ocp_install` role

# Is there a relevant Issue open for this?

No

# Other Relevant info, PRs, etc

No