### PR TITLE
Add aap_secret_rotate role for SECRET_KEY rotation across AAP 2.7 components

### DIFF
--- a/changelogs/fragments/aap_secret_rotate-new-role.yml
+++ b/changelogs/fragments/aap_secret_rotate-new-role.yml
@@ -1,0 +1,8 @@
+---
+major_changes:
+  - >-
+    aap_secret_rotate - new role to rotate SECRET_KEY (database encryption
+    keys) for all AAP 2.7 components (controller, gateway, hub, EDA).
+    Supports Podman and Operator deployment types, with pre/post-flight
+    encrypted field verification, Hub multi-key zero-downtime rotation,
+    and ESO/ArgoCD-aware GitOps pausing.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -45,5 +45,6 @@ tags:
     - infrastructure
 dependencies:
     "ansible.posix": ">=1.0.0"
+    "containers.podman": ">=1.7.0"
     "kubernetes.core": ">=2.2.0"
 ...

--- a/roles/aap_secret_rotate/README.md
+++ b/roles/aap_secret_rotate/README.md
@@ -1,0 +1,217 @@
+# aap_secret_rotate
+
+Rotate database encryption secret keys across all Ansible Automation Platform 2.7 components. Supports both **podman** (containerised installer) and **operator** (Kubernetes/OpenShift) deployments.
+
+## Components
+
+| Component | Management Command | Key Source |
+| --- | --- | --- |
+| Controller | `awx-manage regenerate_secret_key --use-custom-key` | `TOWER_SECRET_KEY` env var |
+| Gateway | `aap-gateway-manage rotate_secret_key --use-custom-key` | `GATEWAY_SECRET_KEY` env var |
+| EDA | `aap-eda-manage rotate_db_encryption_key --use-custom-key` | `EDA_DB_ROTATION_KEY` env var |
+| Hub | `pulpcore-manager rotate-db-key` | Multi-key file (Fernet) |
+
+## Prerequisites
+
+1. **Database backup**: Always back up the AAP database before rotating keys. This role does **not** perform database backups. Use the AAP installer's `backup.yml` playbook (podman) or the `AnsibleAutomationPlatformBackup` CR (operator).
+
+2. **Podman deployments**: SSH access to the AAP host with permissions to manage podman containers and secrets.
+
+3. **Operator deployments**: `kubectl` or `oc` (or any compatible CLI) configured with access to the AAP namespace. The role auto-detects which binary is available. Required permissions:
+   - `Secret`: get, list, create, update, patch
+   - `Job`: create, get, list, delete
+   - `Deployment`: get, list
+   - `AnsibleAutomationPlatform` CR: get, patch
+   - `ExternalSecret` (if ESO-managed): get, list, patch
+   - `Application` (if ArgoCD-managed): get, list, patch
+
+## Variables
+
+### General
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `aap_secret_rotate_components` | `[controller, hub, eda, gateway]` | Components to rotate, in order. Gateway should be last (session invalidation). |
+| `aap_secret_rotate_deployment_type` | `""` (auto-detect) | `podman` or `operator`. Auto-detected if empty. |
+| `aap_secret_rotate_dry_run` | `false` | Report what would change without writing. Components that support native `--dry-run` (Gateway, EDA) will use it. |
+| `aap_secret_rotate_backup_dir` | `{{ playbook_dir }}/secret_backups/{{ date }}` | Directory on the control node for key backups. |
+
+### Custom Keys
+
+If left empty, a new Fernet-compatible key is auto-generated per component.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `aap_secret_rotate_controller_key` | `""` | Custom key for Controller |
+| `aap_secret_rotate_gateway_key` | `""` | Custom key for Gateway |
+| `aap_secret_rotate_eda_key` | `""` | Custom key for EDA |
+| `aap_secret_rotate_hub_key` | `""` | Custom key for Hub |
+
+### Operator-specific
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `aap_secret_rotate_namespace` | `aap` | Kubernetes namespace containing the AAP installation |
+| `aap_secret_rotate_cr_name` | `aap` | Name of the `AnsibleAutomationPlatform` CR |
+| `aap_secret_rotate_idle_timeout` | `300` | Seconds to wait for pods to terminate after idling |
+| `aap_secret_rotate_rollout_timeout` | `300` | Seconds to wait for pods to become ready after un-idling |
+| `aap_secret_rotate_kubectl_binary` | `""` (auto-detect) | Path to kubectl-compatible CLI. Auto-detected: tries `kubectl`, falls back to `oc`. |
+
+### External Secrets Operator (ESO)
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `aap_secret_rotate_eso_managed` | `""` (auto-detect) | Whether secrets are managed by ESO. Auto-detected by looking for `ExternalSecret` resources in the AAP namespace. |
+| `aap_secret_rotate_eso_resume_after` | `false` | Resume ESO reconciliation after rotation. If `false`, ExternalSecrets stay paused until the external store is updated manually. |
+
+### ArgoCD / GitOps
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `aap_secret_rotate_argocd_managed` | `""` (auto-detect) | Whether the deployment is managed by ArgoCD. Auto-detected by looking for an Application targeting the AAP namespace. |
+| `aap_secret_rotate_argocd_app_name` | `""` (auto-detect) | ArgoCD Application name. Auto-detected if empty. |
+| `aap_secret_rotate_argocd_app_namespace` | `""` (auto-detect) | Namespace where the ArgoCD Application CR lives. Auto-detected by cluster-wide search. Override if RBAC restricts cluster-wide Application listing. |
+| `aap_secret_rotate_argocd_resume_after` | `false` | Resume ArgoCD auto-sync after rotation. If `false`, the Application stays suspended until the Git repo is updated. |
+
+### Podman-specific
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `aap_secret_rotate_controller_container` | `automation-controller-task` | Controller container name |
+| `aap_secret_rotate_gateway_container` | `automation-gateway` | Gateway container name |
+| `aap_secret_rotate_eda_container` | `automation-eda-api` | EDA container name |
+| `aap_secret_rotate_hub_container` | `automation-hub-api` | Hub container name |
+
+## Usage
+
+### Dry Run (recommended first step)
+
+```yaml
+- name: AAP Secret Key Rotation (dry run)
+  hosts: aap
+  roles:
+    - role: infra.aap_utilities.aap_secret_rotate
+      aap_secret_rotate_dry_run: true
+```
+
+### Full Rotation (podman)
+
+```yaml
+- name: AAP Secret Key Rotation
+  hosts: aap
+  become: true
+  roles:
+    - role: infra.aap_utilities.aap_secret_rotate
+      aap_secret_rotate_deployment_type: podman
+```
+
+### Full Rotation (operator on any Kubernetes)
+
+```yaml
+- name: AAP Secret Key Rotation
+  hosts: localhost
+  connection: local
+  roles:
+    - role: infra.aap_utilities.aap_secret_rotate
+      aap_secret_rotate_deployment_type: operator
+      aap_secret_rotate_namespace: my-aap
+      aap_secret_rotate_cr_name: my-aap
+```
+
+### Operator with ESO and ArgoCD (enterprise GitOps)
+
+```yaml
+- name: AAP Secret Key Rotation (GitOps environment)
+  hosts: localhost
+  connection: local
+  roles:
+    - role: infra.aap_utilities.aap_secret_rotate
+      aap_secret_rotate_deployment_type: operator
+      aap_secret_rotate_namespace: aap-prod
+      aap_secret_rotate_cr_name: aap
+      # ESO and ArgoCD (including the Application namespace) are
+      # auto-detected; override only if cluster-wide listing is restricted:
+      # aap_secret_rotate_eso_managed: true
+      # aap_secret_rotate_argocd_managed: true
+      # aap_secret_rotate_argocd_app_name: aap-prod
+      # aap_secret_rotate_argocd_app_namespace: argocd
+```
+
+After the playbook completes, you will see action-required messages telling you to:
+
+1. Update the new key values in your external secret store (Vault, AWS SM, etc.)
+2. Update your Git repository with the new secret references (SealedSecrets, SOPS, etc.)
+3. Resume ESO reconciliation and ArgoCD auto-sync
+
+### Single Component
+
+```yaml
+- name: Rotate Controller key only
+  hosts: aap
+  become: true
+  roles:
+    - role: infra.aap_utilities.aap_secret_rotate
+      aap_secret_rotate_components:
+        - controller
+```
+
+## How It Works
+
+### Lifecycle
+
+1. **Preflight**: Detect deployment type, validate components, detect ESO/ArgoCD
+2. **Backup**: Read and save current keys to the control node
+3. **Generate**: Create new Fernet-compatible keys (or use provided custom keys)
+4. **Pause GitOps** (operator only): Suspend ArgoCD auto-sync, pause ESO reconciliation
+5. **Idle/Stop**: For operator, idle the entire platform. For podman, stop containers per component.
+6. **Rotate**: Run each component's management command with the new key
+7. **Write**: Update the secret storage (podman secret or K8s Secret) with the new key
+8. **Un-idle/Start**: Bring services back up
+9. **Resume GitOps** (optional): Resume ESO/ArgoCD if configured
+10. **Verify**: Check platform health, display post-rotation action items
+
+### Hub's Multi-Key File
+
+Hub uses a different mechanism from the other components. Its `DB_ENCRYPTION_KEY` is a Fernet symmetric key stored in a file that supports multiple keys (one per line). The first key encrypts new data, all keys can decrypt existing data.
+
+The rotation process:
+
+1. Write multi-key file: new key on line 1, old key on line 2
+2. Run `pulpcore-manager rotate-db-key` to re-encrypt all data with the new key
+3. Write final file with only the new key
+
+### Operator Deployment Flow
+
+For operator deployments, the role idles the entire `AnsibleAutomationPlatform` CR once (sets `spec.idle_aap: true`), runs rotation Jobs for each component, patches the K8s Secrets, then un-idles. This avoids multiple scale-down/up cycles.
+
+### Enterprise GitOps (ESO + ArgoCD)
+
+Many enterprise customers manage AAP operator deployments using a GitOps pattern:
+
+- **External Secrets Operator (ESO)** syncs secret values from an external store (HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, etc.) into Kubernetes Secrets.
+- **ArgoCD** manages the AAP CR and namespace resources declaratively from a Git repository.
+
+The role handles this by:
+
+1. **Auto-detecting** ESO-managed secrets (looks for `ExternalSecret` resources) and ArgoCD-managed Applications (looks for `Application` resources targeting the AAP namespace) during preflight.
+2. **Pausing ESO reconciliation** by annotating `ExternalSecret` resources with `reconcile.external-secrets.io/disabled: "true"`, preventing ESO from overwriting the rotated key values.
+3. **Suspending ArgoCD auto-sync** by removing `spec.syncPolicy.automated` from the Application, preventing ArgoCD from reverting the `idle_aap` patch or secret changes.
+4. **Displaying clear action items** after rotation, telling the operator exactly what needs updating in the external secret store and Git repo.
+5. **Optionally resuming** ESO and ArgoCD if `aap_secret_rotate_eso_resume_after` or `aap_secret_rotate_argocd_resume_after` are set to `true`. By default both stay paused, which is the safe option: it ensures the operator updates the source of truth before the controllers resume.
+
+### Podman Deployment Flow
+
+For podman deployments, each component's containers are stopped individually, the management command is executed in the container, the podman secret is replaced, and containers are restarted.
+
+## Supported Versions
+
+- AAP 2.7 (all components)
+- EDA rotation also available in AAP 2.6.20260715+
+
+## Backups
+
+Current key values are saved to `{{ aap_secret_rotate_backup_dir }}/aap_secret_keys.bak` on the control node before any rotation occurs. Store this file securely; it contains the keys needed to decrypt the database if rollback is necessary.
+
+## Licence
+
+GPL-3.0-or-later

--- a/roles/aap_secret_rotate/defaults/main.yml
+++ b/roles/aap_secret_rotate/defaults/main.yml
@@ -1,0 +1,79 @@
+---
+# Which components to rotate (order matters: Gateway last, it handles sessions)
+aap_secret_rotate_components:
+  - controller
+  - hub
+  - eda
+  - gateway
+
+# Deployment type: "podman" or "operator" (auto-detected if omitted)
+aap_secret_rotate_deployment_type: ""
+
+# Dry run: report what would change without writing
+aap_secret_rotate_dry_run: false
+
+# Skip pre-rotation encryption verification (NOT recommended)
+aap_secret_rotate_skip_preflight: false
+
+# Skip post-rotation encryption verification
+aap_secret_rotate_skip_postflight: false
+
+# Backup directory for current keys (on the controller node)
+aap_secret_rotate_backup_dir: "{{ playbook_dir }}/secret_backups/{{ ansible_date_time.date | default(lookup('pipe', 'date +%Y-%m-%d')) }}"
+
+# Custom keys (empty = auto-generate a Fernet-compatible key per component)
+aap_secret_rotate_controller_key: ""
+aap_secret_rotate_gateway_key: ""
+aap_secret_rotate_eda_key: ""
+aap_secret_rotate_hub_key: ""
+
+# ── Operator-specific ──────────────────────────────────────────────────
+aap_secret_rotate_namespace: "aap"
+aap_secret_rotate_cr_name: "aap"
+aap_secret_rotate_idle_timeout: 300
+aap_secret_rotate_rollout_timeout: 300
+
+# Path to the kubectl-compatible CLI binary (auto-detected if empty).
+# Works with kubectl, oc, or any compatible binary.
+aap_secret_rotate_kubectl_binary: ""
+
+# ── External Secrets Operator (ESO) ───────────────────────────────────
+# Auto-detected if empty. Set to true/false to override.
+# When true, ExternalSecret resources are paused before patching K8s
+# Secrets so that ESO does not overwrite the rotated values.
+aap_secret_rotate_eso_managed: ""
+
+# Whether to resume ESO sync after rotation completes.
+# If false, ExternalSecrets stay paused until the operator updates
+# the external secret store (Vault, AWS SM, etc.) and resumes manually.
+aap_secret_rotate_eso_resume_after: false
+
+# ── ArgoCD / GitOps ──────────────────────────────────────────────────
+# Auto-detected if empty. Set to true/false to override.
+# When true, ArgoCD auto-sync is suspended before mutating the AAP CR
+# to prevent ArgoCD from reverting the idle_aap patch.
+aap_secret_rotate_argocd_managed: ""
+
+# ArgoCD Application name that manages the AAP namespace.
+# Auto-detected if empty (looks for Applications targeting the namespace).
+aap_secret_rotate_argocd_app_name: ""
+
+# ArgoCD Application namespace (where the Application CR lives).
+# Auto-detected if empty. Override with e.g. "argocd" or "openshift-gitops".
+aap_secret_rotate_argocd_app_namespace: ""
+
+# Whether to resume ArgoCD auto-sync after rotation completes.
+# If false, the Application stays suspended until the operator
+# updates the Git repo and resumes manually.
+aap_secret_rotate_argocd_resume_after: false
+
+# ── Podman-specific ────────────────────────────────────────────────────
+# Container names (defaults match AAP 2.7 containerised installer)
+aap_secret_rotate_controller_container: "automation-controller-task"
+aap_secret_rotate_gateway_container: "automation-gateway"
+aap_secret_rotate_eda_container: "automation-eda-api"
+aap_secret_rotate_hub_container: "automation-hub-api"
+
+# Podman systemd service prefix (used for stop/start)
+aap_secret_rotate_systemd_scope: "user"
+...

--- a/roles/aap_secret_rotate/meta/argument_specs.yml
+++ b/roles/aap_secret_rotate/meta/argument_specs.yml
@@ -1,0 +1,104 @@
+---
+argument_specs:
+  main:
+    short_description: Rotate SECRET_KEY across AAP 2.7 components
+    description:
+      - Rotates database encryption keys for Ansible Automation Platform 2.7 components.
+      - Supports both podman (containerised installer) and operator (Kubernetes/OpenShift) deployments.
+      - Covers Automation Controller, Gateway, Event-Driven Ansible, and Automation Hub.
+    options:
+      aap_secret_rotate_components:
+        description: List of components to rotate. Order matters.
+        type: list
+        elements: str
+        default:
+          - controller
+          - hub
+          - eda
+          - gateway
+      aap_secret_rotate_deployment_type:
+        description: Deployment type. Auto-detected if empty.
+        type: str
+        choices:
+          - podman
+          - operator
+          - ""
+        default: ""
+      aap_secret_rotate_dry_run:
+        description: Report what would change without writing.
+        type: bool
+        default: false
+      aap_secret_rotate_backup_dir:
+        description: Directory on the control node for key backups.
+        type: str
+      aap_secret_rotate_controller_key:
+        description: Custom key for Controller. Auto-generated if empty.
+        type: str
+        default: ""
+      aap_secret_rotate_gateway_key:
+        description: Custom key for Gateway. Auto-generated if empty.
+        type: str
+        default: ""
+      aap_secret_rotate_eda_key:
+        description: Custom key for EDA. Auto-generated if empty.
+        type: str
+        default: ""
+      aap_secret_rotate_hub_key:
+        description: Custom key for Hub. Auto-generated if empty.
+        type: str
+        default: ""
+      aap_secret_rotate_namespace:
+        description: Kubernetes namespace (operator deployments).
+        type: str
+        default: aap
+      aap_secret_rotate_cr_name:
+        description: AnsibleAutomationPlatform CR name (operator deployments).
+        type: str
+        default: aap
+      aap_secret_rotate_eso_managed:
+        description: >-
+          Whether secrets are managed by External Secrets Operator.
+          Auto-detected if empty. When true, ExternalSecret resources are
+          paused before patching K8s Secrets.
+        type: str
+        default: ""
+      aap_secret_rotate_eso_resume_after:
+        description: >-
+          Whether to resume ESO reconciliation after rotation. If false,
+          ExternalSecrets stay paused until the external store is updated.
+        type: bool
+        default: false
+      aap_secret_rotate_argocd_managed:
+        description: >-
+          Whether the AAP deployment is managed by ArgoCD. Auto-detected
+          if empty. When true, auto-sync is suspended during rotation.
+        type: str
+        default: ""
+      aap_secret_rotate_argocd_app_name:
+        description: >-
+          ArgoCD Application name managing the AAP namespace.
+          Auto-detected if empty.
+        type: str
+        default: ""
+      aap_secret_rotate_argocd_app_namespace:
+        description: >-
+          Namespace where the ArgoCD Application CR lives.
+          Auto-detected by searching all namespaces for an Application
+          targeting the AAP namespace. Override with e.g. argocd or
+          openshift-gitops if cluster-wide listing is restricted.
+        type: str
+        default: ""
+      aap_secret_rotate_kubectl_binary:
+        description: >-
+          Path to a kubectl-compatible CLI binary. Auto-detected if empty
+          (tries kubectl, falls back to oc). Works with any Kubernetes
+          distribution.
+        type: str
+        default: ""
+      aap_secret_rotate_argocd_resume_after:
+        description: >-
+          Whether to resume ArgoCD auto-sync after rotation. If false,
+          the Application stays suspended until the Git repo is updated.
+        type: bool
+        default: false
+...

--- a/roles/aap_secret_rotate/meta/main.yml
+++ b/roles/aap_secret_rotate/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  author: Alexey Masolov
+  description: Rotate SECRET_KEY across all Ansible Automation Platform 2.7 components
+  company: Red Hat
+
+  license: GPL-3.0-or-later
+
+  min_ansible_version: "2.15"
+
+  platforms:
+    - name: EL
+      versions:
+        - "9"
+
+  galaxy_tags:
+    - aap
+    - security
+    - encryption
+
+dependencies: []
+...

--- a/roles/aap_secret_rotate/tasks/backup_secrets.yml
+++ b/roles/aap_secret_rotate/tasks/backup_secrets.yml
@@ -1,0 +1,34 @@
+---
+- name: Create backup directory
+  ansible.builtin.file:
+    path: "{{ aap_secret_rotate_backup_dir }}"
+    state: directory
+    mode: "0700"
+  delegate_to: localhost
+  run_once: true
+
+- name: Back up current secrets for each component
+  ansible.builtin.include_tasks: "{{ aap_secret_rotate_deployment_type }}/read_secret.yml"
+  vars:
+    _component: "{{ item }}"
+    _component_config: "{{ __aap_secret_rotate_components[item] }}"
+  loop: "{{ aap_secret_rotate_components }}"
+
+- name: Write backup manifest
+  ansible.builtin.copy:
+    content: |
+      # AAP Secret Key Backup
+      # Generated: {{ ansible_date_time.iso8601 }}
+      # Host: {{ inventory_hostname }}
+      # Deployment type: {{ aap_secret_rotate_deployment_type }}
+      #
+      # Keep this file secure. It contains the encryption keys needed
+      # to decrypt all secrets in the AAP database.
+      {% for comp in aap_secret_rotate_components %}
+      {{ comp }}: {{ __aap_secret_rotate_backup_keys[comp] | default('NOT_RETRIEVED') }}
+      {% endfor %}
+    dest: "{{ aap_secret_rotate_backup_dir }}/aap_secret_keys.bak"
+    mode: "0600"
+  delegate_to: localhost
+  no_log: true
+...

--- a/roles/aap_secret_rotate/tasks/generate_keys.yml
+++ b/roles/aap_secret_rotate/tasks/generate_keys.yml
@@ -1,0 +1,16 @@
+---
+- name: Initialise new keys dictionary
+  ansible.builtin.set_fact:
+    __aap_secret_rotate_new_keys: {}
+
+- name: Generate or assign keys for each component
+  ansible.builtin.include_tasks: generate_single_key.yml
+  vars:
+    _component: "{{ item }}"
+    _component_config: "{{ __aap_secret_rotate_components[item] }}"
+  loop: "{{ aap_secret_rotate_components }}"
+
+- name: Display key generation summary
+  ansible.builtin.debug:
+    msg: "Keys prepared for: {{ __aap_secret_rotate_new_keys.keys() | list | join(', ') }}"
+...

--- a/roles/aap_secret_rotate/tasks/generate_single_key.yml
+++ b/roles/aap_secret_rotate/tasks/generate_single_key.yml
@@ -1,0 +1,22 @@
+---
+- name: Use provided custom key for {{ _component }}
+  ansible.builtin.set_fact:
+    __aap_secret_rotate_new_keys: "{{ __aap_secret_rotate_new_keys | combine({_component: _component_config.custom_key_var}) }}"
+  when: _component_config.custom_key_var | length > 0
+  no_log: true
+
+- name: Generate new Fernet-compatible key for {{ _component }}
+  when: _component_config.custom_key_var | length == 0
+  block:
+    - name: Generate random key material for {{ _component }}
+      ansible.builtin.command:
+        cmd: openssl rand -base64 32
+      register: __aap_secret_rotate_generated_key
+      changed_when: false
+      delegate_to: localhost
+
+    - name: Store generated key for {{ _component }}
+      ansible.builtin.set_fact:
+        __aap_secret_rotate_new_keys: "{{ __aap_secret_rotate_new_keys | combine({_component: __aap_secret_rotate_generated_key.stdout | trim}) }}"
+      no_log: true
+...

--- a/roles/aap_secret_rotate/tasks/main.yml
+++ b/roles/aap_secret_rotate/tasks/main.yml
@@ -1,0 +1,139 @@
+---
+# AAP Secret Key Rotation Orchestrator
+#
+# Prerequisites:
+#   - Database backup completed BEFORE running this role
+#   - For podman: SSH access to the AAP host with podman permissions
+#   - For operator: kubectl/oc access to the Kubernetes cluster with
+#     permissions to read/write Secrets and patch the AAP CR
+
+- name: Preflight checks
+  ansible.builtin.include_tasks: preflight.yml
+
+- name: Pre-rotation encryption verification
+  ansible.builtin.include_tasks: preflight_check.yml
+  when: not (aap_secret_rotate_skip_preflight | bool)
+
+- name: Back up current secret keys
+  ansible.builtin.include_tasks: backup_secrets.yml
+
+- name: Generate new keys
+  ansible.builtin.include_tasks: generate_keys.yml
+
+# ── GitOps / ESO safety: pause external controllers ──────────────────
+# If ArgoCD manages the AAP namespace, suspend auto-sync so it does not
+# revert the idle_aap patch or secret changes during rotation.
+- name: Pause ArgoCD auto-sync (operator + ArgoCD)
+  ansible.builtin.include_tasks: operator/pause_argocd.yml
+  when:
+    - aap_secret_rotate_deployment_type == 'operator'
+    - aap_secret_rotate_argocd_managed | bool
+
+# If secrets are managed by External Secrets Operator, pause
+# reconciliation so ESO does not overwrite rotated values.
+- name: Pause ESO reconciliation (operator + ESO)
+  ansible.builtin.include_tasks: operator/pause_eso.yml
+  when:
+    - aap_secret_rotate_deployment_type == 'operator'
+    - aap_secret_rotate_eso_managed | bool
+
+# ── Rotate each component ───────────────────────────────────────────
+# Controller and Hub are independent, EDA next, Gateway last (sessions).
+# For operator deployments, rotation execs into running pods, updates
+# the K8s Secret, and triggers a rollout restart per component.
+- name: Rotate controller
+  ansible.builtin.include_tasks: rotate_controller.yml
+  when: "'controller' in aap_secret_rotate_components"
+
+- name: Rotate hub
+  ansible.builtin.include_tasks: rotate_hub.yml
+  when: "'hub' in aap_secret_rotate_components"
+
+- name: Rotate EDA
+  ansible.builtin.include_tasks: rotate_eda.yml
+  when: "'eda' in aap_secret_rotate_components"
+
+- name: Rotate gateway
+  ansible.builtin.include_tasks: rotate_gateway.yml
+  when: "'gateway' in aap_secret_rotate_components"
+
+# ── Resume external controllers (optional) ──────────────────────────
+- name: Resume ESO reconciliation (operator + ESO)
+  ansible.builtin.include_tasks: operator/resume_eso.yml
+  when:
+    - aap_secret_rotate_deployment_type == 'operator'
+    - aap_secret_rotate_eso_managed | bool
+    - aap_secret_rotate_eso_resume_after | bool
+
+- name: Resume ArgoCD auto-sync (operator + ArgoCD)
+  ansible.builtin.include_tasks: operator/resume_argocd.yml
+  when:
+    - aap_secret_rotate_deployment_type == 'operator'
+    - aap_secret_rotate_argocd_managed | bool
+    - aap_secret_rotate_argocd_resume_after | bool
+
+# ── Verify and report ───────────────────────────────────────────────
+- name: Post-rotation encryption verification
+  ansible.builtin.include_tasks: postflight_check.yml
+  when:
+    - not aap_secret_rotate_dry_run
+    - not (aap_secret_rotate_skip_postflight | bool)
+
+- name: Verify platform health
+  ansible.builtin.include_tasks: verify.yml
+  when: not aap_secret_rotate_dry_run
+
+- name: Display post-rotation actions for ESO-managed secrets
+  ansible.builtin.debug:
+    msg: |-
+      ╔══════════════════════════════════════════════════════════════════╗
+      ║  ACTION REQUIRED: External Secrets Operator                    ║
+      ╠══════════════════════════════════════════════════════════════════╣
+      ║  ESO reconciliation has been PAUSED to protect rotated keys.   ║
+      ║                                                                ║
+      ║  You must now:                                                 ║
+      ║  1. Update the new key values in your external secret store    ║
+      ║     (Vault, AWS Secrets Manager, Azure Key Vault, etc.)        ║
+      ║  2. Resume ESO reconciliation:                                 ║
+      ║     {{ aap_secret_rotate_kubectl_binary }} -n {{ aap_secret_rotate_namespace }} annotate externalsecret --all  ║
+      ║       reconcile.external-secrets.io/disabled=false             ║
+      ║       --overwrite                                              ║
+      ║                                                                ║
+      ║  New keys are in: {{ aap_secret_rotate_backup_dir }}           ║
+      ╚══════════════════════════════════════════════════════════════════╝
+  when:
+    - aap_secret_rotate_deployment_type == 'operator'
+    - aap_secret_rotate_eso_managed | bool
+    - not (aap_secret_rotate_eso_resume_after | bool)
+    - not aap_secret_rotate_dry_run
+
+- name: Display post-rotation actions for ArgoCD-managed deployment
+  ansible.builtin.debug:
+    msg: |-
+      ╔══════════════════════════════════════════════════════════════════╗
+      ║  ACTION REQUIRED: ArgoCD / GitOps                              ║
+      ╠══════════════════════════════════════════════════════════════════╣
+      ║  ArgoCD auto-sync has been SUSPENDED on Application            ║
+      ║  '{{ aap_secret_rotate_argocd_app_name }}'.                    ║
+      ║                                                                ║
+      ║  You must now:                                                 ║
+      ║  1. Update your Git repo to reflect the new secret values      ║
+      ║     (or sealed/encrypted equivalents)                          ║
+      ║  2. Update spec.idle_aap back to false in Git (if tracked)     ║
+      ║  3. Resume ArgoCD sync:                                        ║
+      ║     argocd app set {{ aap_secret_rotate_argocd_app_name }}     ║
+      ║       --sync-policy automated                                  ║
+      ╚══════════════════════════════════════════════════════════════════╝
+  when:
+    - aap_secret_rotate_deployment_type == 'operator'
+    - aap_secret_rotate_argocd_managed | bool
+    - not (aap_secret_rotate_argocd_resume_after | bool)
+    - not aap_secret_rotate_dry_run
+
+- name: Rotation complete
+  ansible.builtin.debug:
+    msg: >-
+      Secret key rotation {{ 'DRY RUN ' if aap_secret_rotate_dry_run else '' }}complete.
+      Components: {{ aap_secret_rotate_components | join(', ') }}.
+      Backup saved to: {{ aap_secret_rotate_backup_dir }}/aap_secret_keys.bak
+...

--- a/roles/aap_secret_rotate/tasks/operator/exec_command.yml
+++ b/roles/aap_secret_rotate/tasks/operator/exec_command.yml
@@ -1,0 +1,83 @@
+---
+# Executes a management command inside a running pod via kubectl exec.
+# Required vars: _component, _component_config, _exec_env (dict), _exec_cmd (string)
+#
+# Uses exec on a running pod rather than creating a Job, because the
+# pod already has all the necessary volume mounts, environment variables,
+# and database connectivity.
+#
+# Discovers pods by reading the Deployment's selector labels to handle
+# components that use non-standard label conventions (e.g. Hub).
+
+- name: Get deployment selector for {{ _component }}
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: "{{ __aap_secret_rotate_k8s_exec[_component].deployment }}"
+    namespace: "{{ aap_secret_rotate_namespace }}"
+  register: __aap_secret_rotate_deploy_info
+  when: not aap_secret_rotate_dry_run
+
+- name: Build pod selector for {{ _component }}
+  ansible.builtin.set_fact:
+    __aap_secret_rotate_pod_selector: >-
+      {{ __aap_secret_rotate_deploy_info.resources[0].spec.selector.matchLabels
+         | dict2items | map(attribute='key') | zip(
+           __aap_secret_rotate_deploy_info.resources[0].spec.selector.matchLabels
+           | dict2items | map(attribute='value')
+         ) | map('join', '=') | join(',') }}
+  when: not aap_secret_rotate_dry_run
+
+- name: Wait for a ready pod for {{ _component }}
+  ansible.builtin.command:
+    cmd: >-
+      {{ aap_secret_rotate_kubectl_binary }} -n {{ aap_secret_rotate_namespace }}
+      wait pod -l {{ __aap_secret_rotate_pod_selector }}
+      --for=condition=Ready --timeout=300s
+  register: __aap_secret_rotate_pod_wait
+  changed_when: false
+  when: not aap_secret_rotate_dry_run
+
+- name: Find a running pod for {{ _component }}
+  ansible.builtin.command:
+    cmd: >-
+      {{ aap_secret_rotate_kubectl_binary }} -n {{ aap_secret_rotate_namespace }}
+      get pods -l {{ __aap_secret_rotate_pod_selector }}
+      --field-selector=status.phase=Running
+      -o jsonpath={.items[0].metadata.name}
+  register: __aap_secret_rotate_exec_pod
+  changed_when: false
+  failed_when: __aap_secret_rotate_exec_pod.rc != 0 or __aap_secret_rotate_exec_pod.stdout | length == 0
+  when: not aap_secret_rotate_dry_run
+
+- name: Build exec command with env overrides for {{ _component }}
+  ansible.builtin.set_fact:
+    __aap_secret_rotate_full_exec_cmd: >-
+      {% if _exec_env | default({}) | length > 0 %}env
+      {% for key, value in _exec_env.items() %}{{ key }}={{ value }} {% endfor %}{% endif %}{{ _exec_cmd }}
+  no_log: true
+
+- name: Run management command in pod for {{ _component }}
+  ansible.builtin.command:
+    cmd: >-
+      {{ aap_secret_rotate_kubectl_binary }} -n {{ aap_secret_rotate_namespace }}
+      exec {{ __aap_secret_rotate_exec_pod.stdout }}
+      -c {{ __aap_secret_rotate_k8s_exec[_component].container }}
+      -- bash -c {{ __aap_secret_rotate_full_exec_cmd | quote }}
+  register: __aap_secret_rotate_exec_result
+  changed_when: not aap_secret_rotate_dry_run
+  no_log: true
+  when: not aap_secret_rotate_dry_run
+
+- name: Display command output for {{ _component }}
+  ansible.builtin.debug:
+    msg: "{{ __aap_secret_rotate_exec_result.stdout_lines | default([]) }}"
+  when:
+    - not aap_secret_rotate_dry_run
+    - __aap_secret_rotate_exec_result.stdout_lines | default([]) | length > 0
+
+- name: Dry run - would exec rotation command for {{ _component }}
+  ansible.builtin.debug:
+    msg: "[DRY RUN] Would exec '{{ _exec_cmd }}' in pod for deployment {{ __aap_secret_rotate_k8s_exec[_component].deployment }}"
+  when: aap_secret_rotate_dry_run
+...

--- a/roles/aap_secret_rotate/tasks/operator/idle_platform.yml
+++ b/roles/aap_secret_rotate/tasks/operator/idle_platform.yml
@@ -1,0 +1,36 @@
+---
+# Idles the AnsibleAutomationPlatform CR to stop all component pods.
+
+- name: Idle AAP platform (stop all components)
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: aap.ansible.com/v1alpha1
+      kind: AnsibleAutomationPlatform
+      metadata:
+        name: "{{ aap_secret_rotate_cr_name }}"
+        namespace: "{{ aap_secret_rotate_namespace }}"
+      spec:
+        idle_aap: true
+  when: not aap_secret_rotate_dry_run
+
+- name: Wait for pods to terminate
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Pod
+    namespace: "{{ aap_secret_rotate_namespace }}"
+    label_selectors:
+      - "app.kubernetes.io/managed-by=aap-operator"
+    field_selectors:
+      - "status.phase=Running"
+  register: _running_pods
+  until: _running_pods.resources | length == 0
+  retries: "{{ (aap_secret_rotate_idle_timeout / 10) | int }}"
+  delay: 10
+  when: not aap_secret_rotate_dry_run
+
+- name: "Dry run: would idle AAP platform"
+  ansible.builtin.debug:
+    msg: "[DRY RUN] Would set spec.idle_aap=true on {{ aap_secret_rotate_cr_name }}"
+  when: aap_secret_rotate_dry_run
+...

--- a/roles/aap_secret_rotate/tasks/operator/pause_argocd.yml
+++ b/roles/aap_secret_rotate/tasks/operator/pause_argocd.yml
@@ -1,0 +1,57 @@
+---
+# Suspends ArgoCD auto-sync on the Application that manages the AAP
+# namespace, preventing ArgoCD from reverting the idle_aap patch or
+# secret changes during rotation.
+
+- name: Read current ArgoCD Application
+  kubernetes.core.k8s_info:
+    api_version: argoproj.io/v1alpha1
+    kind: Application
+    name: "{{ aap_secret_rotate_argocd_app_name }}"
+    namespace: "{{ aap_secret_rotate_argocd_app_namespace }}"
+  register: __aap_secret_rotate_argocd_app
+
+- name: Fail if ArgoCD Application not found
+  ansible.builtin.fail:
+    msg: >-
+      ArgoCD Application '{{ aap_secret_rotate_argocd_app_name }}' not found
+      in namespace '{{ aap_secret_rotate_argocd_app_namespace }}'.
+      Set aap_secret_rotate_argocd_app_name and aap_secret_rotate_argocd_app_namespace
+      to the correct values.
+  when: __aap_secret_rotate_argocd_app.resources | length == 0
+
+- name: Save current sync policy (for resume)
+  ansible.builtin.set_fact:
+    __aap_secret_rotate_argocd_had_auto_sync: >-
+      {{ __aap_secret_rotate_argocd_app.resources[0].spec.syncPolicy.automated is defined }}
+    __aap_secret_rotate_argocd_original_sync_policy: >-
+      {{ __aap_secret_rotate_argocd_app.resources[0].spec.syncPolicy | default({}) }}
+
+- name: Suspend ArgoCD auto-sync
+  kubernetes.core.k8s_json_patch:
+    api_version: argoproj.io/v1alpha1
+    kind: Application
+    name: "{{ aap_secret_rotate_argocd_app_name }}"
+    namespace: "{{ aap_secret_rotate_argocd_app_namespace }}"
+    patch:
+      - op: remove
+        path: /spec/syncPolicy/automated
+  register: __aap_secret_rotate_argocd_suspend
+  failed_when:
+    - __aap_secret_rotate_argocd_suspend is failed
+    - "'not found' not in (__aap_secret_rotate_argocd_suspend.msg | default(''))"
+  when:
+    - not aap_secret_rotate_dry_run
+    - __aap_secret_rotate_argocd_had_auto_sync | bool
+
+- name: Display ArgoCD sync suspension status
+  ansible.builtin.debug:
+    msg: >-
+      ArgoCD auto-sync suspended on Application '{{ aap_secret_rotate_argocd_app_name }}'.
+      {{ 'Auto-sync was already disabled.' if not (__aap_secret_rotate_argocd_had_auto_sync | bool) else '' }}
+
+- name: Dry run - would suspend ArgoCD auto-sync
+  ansible.builtin.debug:
+    msg: "[DRY RUN] Would suspend auto-sync on ArgoCD Application '{{ aap_secret_rotate_argocd_app_name }}'"
+  when: aap_secret_rotate_dry_run
+...

--- a/roles/aap_secret_rotate/tasks/operator/pause_eso.yml
+++ b/roles/aap_secret_rotate/tasks/operator/pause_eso.yml
@@ -1,0 +1,60 @@
+---
+# Pauses ExternalSecret resources that manage AAP secrets so that ESO does
+# not overwrite the rotated key values before the external store is updated.
+
+- name: Find ExternalSecret resources in the AAP namespace
+  kubernetes.core.k8s_info:
+    api_version: external-secrets.io/v1beta1
+    kind: ExternalSecret
+    namespace: "{{ aap_secret_rotate_namespace }}"
+  register: __aap_secret_rotate_eso_resources
+
+- name: Build list of ExternalSecrets that target AAP component secrets
+  ansible.builtin.set_fact:
+    __aap_secret_rotate_eso_to_pause: >-
+      {{ __aap_secret_rotate_eso_resources.resources | default([])
+         | selectattr('spec.target.name', 'defined')
+         | list }}
+
+- name: Save original ExternalSecret refresh intervals (for resume)
+  ansible.builtin.set_fact:
+    __aap_secret_rotate_eso_original_intervals: >-
+      {{ __aap_secret_rotate_eso_original_intervals | default({}) | combine({
+        item.metadata.name: item.spec.refreshInterval | default('1h')
+      }) }}
+  loop: "{{ __aap_secret_rotate_eso_to_pause }}"
+  loop_control:
+    label: "{{ item.metadata.name }}"
+
+- name: Pause ExternalSecret reconciliation
+  kubernetes.core.k8s:
+    state: patched
+    api_version: external-secrets.io/v1beta1
+    kind: ExternalSecret
+    name: "{{ item.metadata.name }}"
+    namespace: "{{ aap_secret_rotate_namespace }}"
+    definition:
+      metadata:
+        annotations:
+          reconcile.external-secrets.io/disabled: "true"
+  loop: "{{ __aap_secret_rotate_eso_to_pause }}"
+  loop_control:
+    label: "{{ item.metadata.name }}"
+  when: not aap_secret_rotate_dry_run
+
+- name: Display paused ExternalSecrets
+  ansible.builtin.debug:
+    msg: >-
+      Paused ESO reconciliation for:
+      {{ __aap_secret_rotate_eso_to_pause | map(attribute='metadata.name') | list | join(', ') }}
+  when: __aap_secret_rotate_eso_to_pause | length > 0
+
+- name: Dry run - would pause ExternalSecrets
+  ansible.builtin.debug:
+    msg: >-
+      [DRY RUN] Would pause ESO reconciliation for:
+      {{ __aap_secret_rotate_eso_to_pause | map(attribute='metadata.name') | list | join(', ') }}
+  when:
+    - aap_secret_rotate_dry_run
+    - __aap_secret_rotate_eso_to_pause | length > 0
+...

--- a/roles/aap_secret_rotate/tasks/operator/read_secret.yml
+++ b/roles/aap_secret_rotate/tasks/operator/read_secret.yml
@@ -1,0 +1,26 @@
+---
+# Reads a Kubernetes secret and stores the value in __aap_secret_rotate_backup_keys[_component].
+# Required vars: _component, _component_config
+
+- name: Read current K8s secret for {{ _component }}
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: "{{ _component_config.k8s_secret }}"
+    namespace: "{{ aap_secret_rotate_namespace }}"
+  register: __aap_secret_rotate_k8s_secret_result
+  no_log: true
+
+- name: Fail if secret not found for {{ _component }}
+  ansible.builtin.fail:
+    msg: "Secret {{ _component_config.k8s_secret }} not found in namespace {{ aap_secret_rotate_namespace }}"
+  when: __aap_secret_rotate_k8s_secret_result.resources | length == 0
+
+- name: Store backup key for {{ _component }}
+  ansible.builtin.set_fact:
+    __aap_secret_rotate_backup_keys: >-
+      {{ __aap_secret_rotate_backup_keys | default({}) | combine({
+        _component: __aap_secret_rotate_k8s_secret_result.resources[0].data[_component_config.k8s_secret_field] | b64decode
+      }) }}
+  no_log: true
+...

--- a/roles/aap_secret_rotate/tasks/operator/resume_argocd.yml
+++ b/roles/aap_secret_rotate/tasks/operator/resume_argocd.yml
@@ -1,0 +1,29 @@
+---
+# Restores ArgoCD auto-sync on the Application after rotation.
+# Only called when aap_secret_rotate_argocd_resume_after is true AND
+# auto-sync was previously enabled.
+
+- name: Restore ArgoCD auto-sync policy
+  kubernetes.core.k8s:
+    state: patched
+    api_version: argoproj.io/v1alpha1
+    kind: Application
+    name: "{{ aap_secret_rotate_argocd_app_name }}"
+    namespace: "{{ aap_secret_rotate_argocd_app_namespace }}"
+    definition:
+      spec:
+        syncPolicy: "{{ __aap_secret_rotate_argocd_original_sync_policy }}"
+  when:
+    - not aap_secret_rotate_dry_run
+    - __aap_secret_rotate_argocd_had_auto_sync | default(false) | bool
+
+- name: Display ArgoCD sync restoration
+  ansible.builtin.debug:
+    msg: "ArgoCD auto-sync restored on Application '{{ aap_secret_rotate_argocd_app_name }}'."
+  when: __aap_secret_rotate_argocd_had_auto_sync | default(false) | bool
+
+- name: ArgoCD auto-sync was not previously enabled
+  ansible.builtin.debug:
+    msg: "ArgoCD auto-sync was not enabled before rotation; no action taken."
+  when: not (__aap_secret_rotate_argocd_had_auto_sync | default(false) | bool)
+...

--- a/roles/aap_secret_rotate/tasks/operator/resume_eso.yml
+++ b/roles/aap_secret_rotate/tasks/operator/resume_eso.yml
@@ -1,0 +1,29 @@
+---
+# Resumes ExternalSecret reconciliation by removing the pause annotation.
+# Only called when aap_secret_rotate_eso_resume_after is true.
+
+- name: Resume ExternalSecret reconciliation
+  kubernetes.core.k8s:
+    state: patched
+    api_version: external-secrets.io/v1beta1
+    kind: ExternalSecret
+    name: "{{ item.metadata.name }}"
+    namespace: "{{ aap_secret_rotate_namespace }}"
+    definition:
+      metadata:
+        annotations:
+          reconcile.external-secrets.io/disabled: "false"
+  loop: "{{ __aap_secret_rotate_eso_to_pause | default([]) }}"
+  loop_control:
+    label: "{{ item.metadata.name }}"
+  when:
+    - not aap_secret_rotate_dry_run
+    - __aap_secret_rotate_eso_to_pause | default([]) | length > 0
+
+- name: Display resumed ExternalSecrets
+  ansible.builtin.debug:
+    msg: >-
+      Resumed ESO reconciliation for:
+      {{ __aap_secret_rotate_eso_to_pause | default([]) | map(attribute='metadata.name') | list | join(', ') }}
+  when: __aap_secret_rotate_eso_to_pause | default([]) | length > 0
+...

--- a/roles/aap_secret_rotate/tasks/operator/rollout_restart.yml
+++ b/roles/aap_secret_rotate/tasks/operator/rollout_restart.yml
@@ -1,0 +1,37 @@
+---
+# Triggers a rollout restart for all deployments of a given component
+# so that pods pick up the updated K8s Secret values.
+# Required vars: _component
+
+- name: Rollout restart deployments for {{ _component }}
+  ansible.builtin.command:
+    cmd: >-
+      {{ aap_secret_rotate_kubectl_binary }} -n {{ aap_secret_rotate_namespace }}
+      rollout restart deployment/{{ item }}
+  loop: "{{ __aap_secret_rotate_k8s_deployments[_component] }}"
+  register: __aap_secret_rotate_rollout_result
+  failed_when:
+    - __aap_secret_rotate_rollout_result.rc != 0
+    - "'not found' not in (__aap_secret_rotate_rollout_result.stderr | default('') | lower)"
+  changed_when: __aap_secret_rotate_rollout_result.rc == 0
+  when: not aap_secret_rotate_dry_run
+
+- name: Wait for rollout to complete for {{ _component }}
+  ansible.builtin.command:
+    cmd: >-
+      {{ aap_secret_rotate_kubectl_binary }} -n {{ aap_secret_rotate_namespace }}
+      rollout status deployment/{{ item }}
+      --timeout={{ aap_secret_rotate_rollout_timeout }}s
+  loop: "{{ __aap_secret_rotate_k8s_deployments[_component] }}"
+  register: __aap_secret_rotate_rollout_status
+  failed_when:
+    - __aap_secret_rotate_rollout_status.rc != 0
+    - "'not found' not in (__aap_secret_rotate_rollout_status.stderr | default('') | lower)"
+  changed_when: false
+  when: not aap_secret_rotate_dry_run
+
+- name: Dry run - would rollout restart for {{ _component }}
+  ansible.builtin.debug:
+    msg: "[DRY RUN] Would rollout restart: {{ __aap_secret_rotate_k8s_deployments[_component] | join(', ') }}"
+  when: aap_secret_rotate_dry_run
+...

--- a/roles/aap_secret_rotate/tasks/operator/unidle_platform.yml
+++ b/roles/aap_secret_rotate/tasks/operator/unidle_platform.yml
@@ -1,0 +1,38 @@
+---
+# Un-idles the AnsibleAutomationPlatform CR to restart all component pods.
+
+- name: Un-idle AAP platform (restart all components)
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: aap.ansible.com/v1alpha1
+      kind: AnsibleAutomationPlatform
+      metadata:
+        name: "{{ aap_secret_rotate_cr_name }}"
+        namespace: "{{ aap_secret_rotate_namespace }}"
+      spec:
+        idle_aap: false
+  when: not aap_secret_rotate_dry_run
+
+- name: Wait for Gateway pod to be ready
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Pod
+    namespace: "{{ aap_secret_rotate_namespace }}"
+    label_selectors:
+      - "app.kubernetes.io/name=gateway"
+    field_selectors:
+      - "status.phase=Running"
+  register: _gateway_pods
+  until:
+    - _gateway_pods.resources | length > 0
+    - _gateway_pods.resources | map(attribute='status.containerStatuses') | flatten | selectattr('ready', 'equalto', true) | list | length > 0
+  retries: "{{ (aap_secret_rotate_rollout_timeout / 10) | int }}"
+  delay: 10
+  when: not aap_secret_rotate_dry_run
+
+- name: "Dry run: would un-idle AAP platform"
+  ansible.builtin.debug:
+    msg: "[DRY RUN] Would set spec.idle_aap=false on {{ aap_secret_rotate_cr_name }}"
+  when: aap_secret_rotate_dry_run
+...

--- a/roles/aap_secret_rotate/tasks/operator/write_secret.yml
+++ b/roles/aap_secret_rotate/tasks/operator/write_secret.yml
@@ -1,0 +1,23 @@
+---
+# Writes a new value to a Kubernetes secret.
+# Required vars: _component, _component_config, _secret_value
+
+- name: Update K8s secret for {{ _component }}
+  kubernetes.core.k8s:
+    state: present
+    definition: |
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: {{ _component_config.k8s_secret }}
+        namespace: {{ aap_secret_rotate_namespace }}
+      stringData:
+        {{ _component_config.k8s_secret_field }}: {{ _secret_value | to_json }}
+  no_log: true
+  when: not aap_secret_rotate_dry_run
+
+- name: Dry run - would update K8s secret for {{ _component }}
+  ansible.builtin.debug:
+    msg: "[DRY RUN] Would update secret '{{ _component_config.k8s_secret }}' field '{{ _component_config.k8s_secret_field }}'"
+  when: aap_secret_rotate_dry_run
+...

--- a/roles/aap_secret_rotate/tasks/podman/exec_command.yml
+++ b/roles/aap_secret_rotate/tasks/podman/exec_command.yml
@@ -1,0 +1,30 @@
+---
+# Executes a management command inside a running podman container.
+# Required vars: _component, _component_config, _exec_env (dict), _exec_cmd (string)
+
+- name: Execute rotation command in container for {{ _component }}
+  ansible.builtin.command:
+    cmd: >-
+      podman exec
+      {% for key, value in _exec_env.items() %}
+      -e {{ key }}={{ value }}
+      {% endfor %}
+      {{ _component_config.podman_container }}
+      {{ _exec_cmd }}
+  register: __aap_secret_rotate_exec_result
+  changed_when: true
+  no_log: true
+  when: not aap_secret_rotate_dry_run
+
+- name: Display command output for {{ _component }}
+  ansible.builtin.debug:
+    msg: "{{ __aap_secret_rotate_exec_result.stdout_lines | default([]) }}"
+  when:
+    - not aap_secret_rotate_dry_run
+    - __aap_secret_rotate_exec_result.stdout_lines | default([]) | length > 0
+
+- name: Dry run - would execute rotation command for {{ _component }}
+  ansible.builtin.debug:
+    msg: "[DRY RUN] Would run '{{ _exec_cmd }}' in container '{{ _component_config.podman_container }}'"
+  when: aap_secret_rotate_dry_run
+...

--- a/roles/aap_secret_rotate/tasks/podman/read_secret.yml
+++ b/roles/aap_secret_rotate/tasks/podman/read_secret.yml
@@ -1,0 +1,21 @@
+---
+# Reads a podman secret value and stores it in __aap_secret_rotate_backup_keys[_component].
+# Required vars: _component, _component_config
+
+- name: Read current podman secret for {{ _component }}
+  ansible.builtin.command:
+    cmd: >-
+      podman secret inspect --showsecret
+      --format "{% raw %}{{ .SecretData }}{% endraw %}"
+      {{ _component_config.podman_secret }}
+  register: __aap_secret_rotate_podman_secret_value
+  changed_when: false
+  no_log: true
+
+- name: Store backup key for {{ _component }}
+  ansible.builtin.set_fact:
+    __aap_secret_rotate_backup_keys: >-
+      {{ __aap_secret_rotate_backup_keys | default({})
+         | combine({_component: __aap_secret_rotate_podman_secret_value.stdout | trim}) }}
+  no_log: true
+...

--- a/roles/aap_secret_rotate/tasks/podman/restart_component.yml
+++ b/roles/aap_secret_rotate/tasks/podman/restart_component.yml
@@ -1,0 +1,48 @@
+---
+# Restarts all containers for a given component by stopping then
+# starting them. This forces each process to reload its settings
+# (including the secret key file) from disk.
+#
+# Required vars: _component
+
+- name: Stop podman containers for {{ _component }}
+  ansible.builtin.command:
+    cmd: "podman stop {{ item }}"
+  loop: "{{ __aap_secret_rotate_podman_containers[_component] }}"
+  register: __aap_secret_rotate_restart_stop
+  failed_when:
+    - __aap_secret_rotate_restart_stop.rc != 0
+    - "'no such container' not in (__aap_secret_rotate_restart_stop.stderr | default('') | lower)"
+  changed_when: __aap_secret_rotate_restart_stop.rc == 0
+  when: not aap_secret_rotate_dry_run
+
+- name: Start podman containers for {{ _component }}
+  ansible.builtin.command:
+    cmd: "podman start {{ item }}"
+  loop: "{{ __aap_secret_rotate_podman_containers[_component] }}"
+  register: __aap_secret_rotate_restart_start
+  failed_when:
+    - __aap_secret_rotate_restart_start.rc != 0
+    - "'no such container' not in (__aap_secret_rotate_restart_start.stderr | default('') | lower)"
+  changed_when: __aap_secret_rotate_restart_start.rc == 0
+  when: not aap_secret_rotate_dry_run
+
+- name: Wait for containers to be running for {{ _component }}
+  ansible.builtin.command:
+    cmd: "podman wait --condition=running {{ item }}"
+  loop: "{{ __aap_secret_rotate_podman_containers[_component] }}"
+  changed_when: false
+  register: __aap_secret_rotate_restart_wait
+  failed_when:
+    - __aap_secret_rotate_restart_wait.rc != 0
+    - "'no such container' not in (__aap_secret_rotate_restart_wait.stderr | default('') | lower)"
+  retries: 6
+  delay: 10
+  until: __aap_secret_rotate_restart_wait.rc == 0 or 'no such container' in (__aap_secret_rotate_restart_wait.stderr | default('') | lower)
+  when: not aap_secret_rotate_dry_run
+
+- name: Dry run - would restart containers for {{ _component }}
+  ansible.builtin.debug:
+    msg: "[DRY RUN] Would restart: {{ __aap_secret_rotate_podman_containers[_component] | join(', ') }}"
+  when: aap_secret_rotate_dry_run
+...

--- a/roles/aap_secret_rotate/tasks/podman/start_component.yml
+++ b/roles/aap_secret_rotate/tasks/podman/start_component.yml
@@ -1,0 +1,34 @@
+---
+# Starts all containers for a given component.
+# Required vars: _component
+
+- name: Start podman containers for {{ _component }}
+  ansible.builtin.command:
+    cmd: "podman start {{ item }}"
+  loop: "{{ __aap_secret_rotate_podman_containers[_component] }}"
+  register: __aap_secret_rotate_start_result
+  failed_when:
+    - __aap_secret_rotate_start_result.rc != 0
+    - "'no such container' not in (__aap_secret_rotate_start_result.stderr | default('') | lower)"
+  changed_when: __aap_secret_rotate_start_result.rc == 0
+  when: not aap_secret_rotate_dry_run
+
+- name: Wait for containers to be running for {{ _component }}
+  ansible.builtin.command:
+    cmd: "podman wait --condition=running {{ item }}"
+  loop: "{{ __aap_secret_rotate_podman_containers[_component] }}"
+  changed_when: false
+  register: __aap_secret_rotate_wait_result
+  failed_when:
+    - __aap_secret_rotate_wait_result.rc != 0
+    - "'no such container' not in (__aap_secret_rotate_wait_result.stderr | default('') | lower)"
+  retries: 6
+  delay: 10
+  until: __aap_secret_rotate_wait_result.rc == 0 or 'no such container' in (__aap_secret_rotate_wait_result.stderr | default('') | lower)
+  when: not aap_secret_rotate_dry_run
+
+- name: Dry run - would start containers for {{ _component }}
+  ansible.builtin.debug:
+    msg: "[DRY RUN] Would start: {{ __aap_secret_rotate_podman_containers[_component] | join(', ') }}"
+  when: aap_secret_rotate_dry_run
+...

--- a/roles/aap_secret_rotate/tasks/podman/stop_component.yml
+++ b/roles/aap_secret_rotate/tasks/podman/stop_component.yml
@@ -1,0 +1,20 @@
+---
+# Stops all containers for a given component.
+# Required vars: _component
+
+- name: Stop podman containers for {{ _component }}
+  ansible.builtin.command:
+    cmd: "podman stop {{ item }}"
+  loop: "{{ __aap_secret_rotate_podman_containers[_component] }}"
+  register: __aap_secret_rotate_stop_result
+  failed_when:
+    - __aap_secret_rotate_stop_result.rc != 0
+    - "'no such container' not in (__aap_secret_rotate_stop_result.stderr | default('') | lower)"
+  changed_when: __aap_secret_rotate_stop_result.rc == 0
+  when: not aap_secret_rotate_dry_run
+
+- name: Dry run - would stop containers for {{ _component }}
+  ansible.builtin.debug:
+    msg: "[DRY RUN] Would stop: {{ __aap_secret_rotate_podman_containers[_component] | join(', ') }}"
+  when: aap_secret_rotate_dry_run
+...

--- a/roles/aap_secret_rotate/tasks/podman/write_secret.yml
+++ b/roles/aap_secret_rotate/tasks/podman/write_secret.yml
@@ -1,0 +1,42 @@
+---
+# Writes a new value to a podman secret (replace) and updates the
+# mounted secret file inside every running container for the component.
+#
+# Podman mounts secrets at container creation time; replacing the
+# podman secret alone does not update the file inside already-running
+# containers. We handle both: the podman secret (so future container
+# recreations use the new value) and the in-container file (so the
+# running process picks up the change immediately).
+#
+# Required vars: _component, _component_config, _secret_value
+
+- name: Replace podman secret for {{ _component }}
+  containers.podman.podman_secret:
+    name: "{{ _component_config.podman_secret }}"
+    data: "{{ _secret_value }}"
+    state: present
+    force: true
+  no_log: true
+  when: not aap_secret_rotate_dry_run
+
+- name: Update secret file inside running containers for {{ _component }}
+  ansible.builtin.command:
+    cmd: >-
+      podman exec --user 0 {{ item }}
+      sh -c 'printf "%s" "$1" > "$2"'
+      -- "{{ _secret_value }}" "{{ __aap_secret_rotate_podman_secret_paths[_component] }}"
+  loop: "{{ __aap_secret_rotate_podman_containers[_component] }}"
+  register: __aap_secret_rotate_write_result
+  failed_when:
+    - __aap_secret_rotate_write_result.rc != 0
+    - "'no such container' not in (__aap_secret_rotate_write_result.stderr | default('') | lower)"
+    - "'container state improper' not in (__aap_secret_rotate_write_result.stderr | default('') | lower)"
+  changed_when: __aap_secret_rotate_write_result.rc == 0
+  no_log: true
+  when: not aap_secret_rotate_dry_run
+
+- name: Dry run - would replace podman secret for {{ _component }}
+  ansible.builtin.debug:
+    msg: "[DRY RUN] Would replace podman secret '{{ _component_config.podman_secret }}' and update in-container files"
+  when: aap_secret_rotate_dry_run
+...

--- a/roles/aap_secret_rotate/tasks/postflight_check.yml
+++ b/roles/aap_secret_rotate/tasks/postflight_check.yml
@@ -1,0 +1,70 @@
+---
+# Post-rotation verification orchestrator.
+# Runs component-specific postflight checks to verify all encrypted fields are
+# decryptable with the NEW key after rotation completes.
+#
+# If any component fails postflight, the play is aborted. Unlike preflight,
+# there is no skip option for postflight since a failure here means the
+# rotation left the system in a broken state.
+
+- name: Display postflight check banner
+  ansible.builtin.debug:
+    msg: |-
+      ╔══════════════════════════════════════════════════════════════════╗
+      ║  Post-rotation verification: checking all encrypted fields     ║
+      ║  are decryptable with the NEW key                              ║
+      ╚══════════════════════════════════════════════════════════════════╝
+
+- name: Run Controller postflight check
+  ansible.builtin.include_tasks: postflight_controller.yml
+  when: "'controller' in aap_secret_rotate_components"
+
+- name: Run Gateway postflight check
+  ansible.builtin.include_tasks: postflight_gateway.yml
+  when:
+    - "'gateway' in aap_secret_rotate_components"
+    - __aap_secret_rotate_gw_has_rotate | default(false) | bool
+
+- name: Run EDA postflight check
+  ansible.builtin.include_tasks: postflight_eda.yml
+  when: "'eda' in aap_secret_rotate_components"
+
+- name: Run Hub postflight check
+  ansible.builtin.include_tasks: postflight_hub.yml
+  when: "'hub' in aap_secret_rotate_components"
+
+- name: Collect postflight results
+  ansible.builtin.set_fact:
+    __aap_secret_rotate_postflight_failures: >-
+      {{
+        ([] if ('controller' not in aap_secret_rotate_components
+                or (__aap_secret_rotate_postflight_controller_ok | default(true) | bool))
+           else ['controller'])
+        + ([] if ('gateway' not in aap_secret_rotate_components
+                  or not (__aap_secret_rotate_gw_has_rotate | default(false) | bool)
+                  or (__aap_secret_rotate_postflight_gateway_ok | default(true) | bool))
+              else ['gateway'])
+        + ([] if ('eda' not in aap_secret_rotate_components
+                  or (__aap_secret_rotate_postflight_eda_ok | default(true) | bool))
+              else ['eda'])
+        + ([] if ('hub' not in aap_secret_rotate_components
+                  or (__aap_secret_rotate_postflight_hub_ok | default(true) | bool))
+              else ['hub'])
+      }}
+
+- name: Display postflight summary
+  ansible.builtin.debug:
+    msg: >-
+      Postflight verification {{ 'PASSED for all components' if
+        (__aap_secret_rotate_postflight_failures | length == 0) else
+        'FAILED for: ' ~ __aap_secret_rotate_postflight_failures | join(', ') }}
+
+- name: Fail if postflight detected undecryptable fields
+  ansible.builtin.fail:
+    msg: >-
+      POSTFLIGHT FAILED: The following components have encrypted fields that cannot
+      be decrypted with the NEW key after rotation: {{ __aap_secret_rotate_postflight_failures | join(', ') }}.
+      This indicates the rotation did not fully complete. Restore from the backup at
+      {{ aap_secret_rotate_backup_dir }}/aap_secret_keys.bak and investigate.
+  when: __aap_secret_rotate_postflight_failures | length > 0
+...

--- a/roles/aap_secret_rotate/tasks/postflight_controller.yml
+++ b/roles/aap_secret_rotate/tasks/postflight_controller.yml
@@ -1,0 +1,60 @@
+---
+# Post-rotation verification for Automation Controller.
+# Verifies all Credential inputs and NotificationTemplate configs are
+# decryptable with the NEW key after rotation.
+
+- name: Run Controller postflight verification
+  ansible.builtin.shell: |
+    {% if aap_secret_rotate_deployment_type == 'podman' %}
+    podman exec {{ __aap_secret_rotate_components.controller.podman_container }} \
+    {% else %}
+    {{ aap_secret_rotate_kubectl_binary }} -n {{ aap_secret_rotate_namespace }} \
+      exec deploy/{{ __aap_secret_rotate_k8s_exec.controller.deployment }} \
+      -c {{ __aap_secret_rotate_k8s_exec.controller.container }} -- \
+    {% endif %}
+      awx-manage shell -c "
+    from awx.main.models import Credential, NotificationTemplate
+    from awx.main.utils.encryption import decrypt_field
+    failed = []
+    for c in Credential.objects.all():
+        for field in c.credential_type.defined_fields:
+            if field in c.inputs:
+                try:
+                    decrypt_field(c, field)
+                except Exception as e:
+                    failed.append(f'Credential({c.pk}).{field}: {e}')
+    for nt in NotificationTemplate.objects.all():
+        try:
+            for key, val in nt.notification_configuration.items():
+                pass
+        except Exception as e:
+            failed.append(f'NotificationTemplate({nt.pk}): {e}')
+    print('POSTFLIGHT_FAIL' if failed else 'POSTFLIGHT_OK')
+    for f in failed:
+        print(f'  {f}')
+    "
+  args:
+    executable: /bin/bash
+  register: __aap_secret_rotate_postflight_controller_result
+  changed_when: false
+  failed_when: false
+
+- name: Evaluate Controller postflight result
+  ansible.builtin.set_fact:
+    __aap_secret_rotate_postflight_controller_ok: >-
+      {{ 'POSTFLIGHT_OK' in (__aap_secret_rotate_postflight_controller_result.stdout | default('')) }}
+    __aap_secret_rotate_postflight_controller_failed_fields: >-
+      {{ __aap_secret_rotate_postflight_controller_result.stdout_lines | default([])
+         | select('match', '^ ') | list }}
+
+- name: Display Controller postflight result
+  ansible.builtin.debug:
+    msg: "Controller postflight: {{ 'PASSED' if (__aap_secret_rotate_postflight_controller_ok | bool) else 'FAILED' }}"
+
+- name: Display Controller postflight failures
+  ansible.builtin.debug:
+    msg: |-
+      Controller has encrypted fields that cannot be decrypted with the NEW key:
+      {{ __aap_secret_rotate_postflight_controller_failed_fields | join('\n') }}
+  when: not (__aap_secret_rotate_postflight_controller_ok | bool)
+...

--- a/roles/aap_secret_rotate/tasks/postflight_eda.yml
+++ b/roles/aap_secret_rotate/tasks/postflight_eda.yml
@@ -1,0 +1,40 @@
+---
+# Post-rotation verification for Event-Driven Ansible.
+# Uses the --dry-run flag of rotate_db_encryption_key to confirm all encrypted
+# fields are decryptable with the new key (expects 0 items needing rotation).
+
+- name: Run EDA postflight dry-run
+  ansible.builtin.command:
+    cmd: >-
+      {% if aap_secret_rotate_deployment_type == 'podman' %}
+      podman exec {{ __aap_secret_rotate_components.eda.podman_container }}
+      {% else %}
+      {{ aap_secret_rotate_kubectl_binary }} -n {{ aap_secret_rotate_namespace }}
+      exec deploy/{{ __aap_secret_rotate_k8s_exec.eda.deployment }}
+      -c {{ __aap_secret_rotate_k8s_exec.eda.container }}
+      --
+      {% endif %}
+      aap-eda-manage rotate_db_encryption_key --dry-run
+  register: __aap_secret_rotate_postflight_eda_result
+  changed_when: false
+  failed_when: false
+
+- name: Evaluate EDA postflight result
+  ansible.builtin.set_fact:
+    __aap_secret_rotate_postflight_eda_ok: >-
+      {{ (__aap_secret_rotate_postflight_eda_result.rc | default(0)) == 0
+         and 'could not be decrypted' not in (__aap_secret_rotate_postflight_eda_result.stdout | default(''))
+         and 'DecryptionError' not in (__aap_secret_rotate_postflight_eda_result.stderr | default('')) }}
+
+- name: Display EDA postflight result
+  ansible.builtin.debug:
+    msg: "EDA postflight: {{ 'PASSED' if (__aap_secret_rotate_postflight_eda_ok | bool) else 'FAILED' }}"
+
+- name: Display EDA postflight errors
+  ansible.builtin.debug:
+    msg: |-
+      EDA has encrypted fields that cannot be decrypted with the NEW key:
+      stdout: {{ __aap_secret_rotate_postflight_eda_result.stdout | default('') }}
+      stderr: {{ __aap_secret_rotate_postflight_eda_result.stderr | default('') }}
+  when: not (__aap_secret_rotate_postflight_eda_ok | bool)
+...

--- a/roles/aap_secret_rotate/tasks/postflight_gateway.yml
+++ b/roles/aap_secret_rotate/tasks/postflight_gateway.yml
@@ -1,0 +1,41 @@
+---
+# Post-rotation verification for Automation Gateway.
+# Uses the --dry-run flag of rotate_secret_key to confirm all encrypted fields
+# are decryptable with the new key (expects 0 items needing rotation).
+
+- name: Run Gateway postflight dry-run
+  ansible.builtin.command:
+    cmd: >-
+      {% if aap_secret_rotate_deployment_type == 'podman' %}
+      podman exec {{ __aap_secret_rotate_components.gateway.podman_container }}
+      {% else %}
+      {{ aap_secret_rotate_kubectl_binary }} -n {{ aap_secret_rotate_namespace }}
+      exec deploy/{{ __aap_secret_rotate_k8s_exec.gateway.deployment }}
+      -c {{ __aap_secret_rotate_k8s_exec.gateway.container }}
+      --
+      {% endif %}
+      aap-gateway-manage rotate_secret_key --dry-run
+  register: __aap_secret_rotate_postflight_gateway_result
+  changed_when: false
+  failed_when: false
+
+- name: Evaluate Gateway postflight result
+  ansible.builtin.set_fact:
+    __aap_secret_rotate_postflight_gateway_ok: >-
+      {{ (__aap_secret_rotate_postflight_gateway_result.rc | default(0)) == 0
+         and 'could not be decrypted' not in (__aap_secret_rotate_postflight_gateway_result.stdout | default(''))
+         and 'could not be decrypted' not in (__aap_secret_rotate_postflight_gateway_result.stderr | default(''))
+         and 'DecryptionError' not in (__aap_secret_rotate_postflight_gateway_result.stderr | default('')) }}
+
+- name: Display Gateway postflight result
+  ansible.builtin.debug:
+    msg: "Gateway postflight: {{ 'PASSED' if (__aap_secret_rotate_postflight_gateway_ok | bool) else 'FAILED' }}"
+
+- name: Display Gateway postflight errors
+  ansible.builtin.debug:
+    msg: |-
+      Gateway has encrypted fields that cannot be decrypted with the NEW key:
+      stdout: {{ __aap_secret_rotate_postflight_gateway_result.stdout | default('') }}
+      stderr: {{ __aap_secret_rotate_postflight_gateway_result.stderr | default('') }}
+  when: not (__aap_secret_rotate_postflight_gateway_ok | bool)
+...

--- a/roles/aap_secret_rotate/tasks/postflight_hub.yml
+++ b/roles/aap_secret_rotate/tasks/postflight_hub.yml
@@ -1,0 +1,61 @@
+---
+# Post-rotation verification for Automation Hub (Pulp).
+# Verifies all Remote objects (password, proxy_password, token) are readable
+# with the new key after rotation.
+
+- name: Run Hub postflight verification
+  ansible.builtin.shell: |
+    {% if aap_secret_rotate_deployment_type == 'podman' %}
+    podman exec {{ __aap_secret_rotate_components.hub.podman_container }} \
+    {% else %}
+    {{ aap_secret_rotate_kubectl_binary }} -n {{ aap_secret_rotate_namespace }} \
+      exec deploy/{{ __aap_secret_rotate_k8s_exec.hub.deployment }} \
+      -c {{ __aap_secret_rotate_k8s_exec.hub.container }} -- \
+    {% endif %}
+      pulpcore-manager shell -c "
+    from pulpcore.app.models import Remote
+    failed = []
+    for r in Remote.objects.all():
+        try:
+            _ = r.password
+            _ = r.proxy_password
+        except Exception as e:
+            failed.append(f'Remote({r.pk}): {e}')
+    try:
+        from pulp_ansible.app.models import AnsibleRemote
+        for r in AnsibleRemote.objects.all():
+            try:
+                _ = r.token
+            except Exception as e:
+                failed.append(f'AnsibleRemote({r.pk}): {e}')
+    except ImportError:
+        pass
+    print('POSTFLIGHT_FAIL' if failed else 'POSTFLIGHT_OK')
+    for f in failed:
+        print(f'  {f}')
+    "
+  args:
+    executable: /bin/bash
+  register: __aap_secret_rotate_postflight_hub_result
+  changed_when: false
+  failed_when: false
+
+- name: Evaluate Hub postflight result
+  ansible.builtin.set_fact:
+    __aap_secret_rotate_postflight_hub_ok: >-
+      {{ 'POSTFLIGHT_OK' in (__aap_secret_rotate_postflight_hub_result.stdout | default('')) }}
+    __aap_secret_rotate_postflight_hub_failed_fields: >-
+      {{ __aap_secret_rotate_postflight_hub_result.stdout_lines | default([])
+         | select('match', '^ ') | list }}
+
+- name: Display Hub postflight result
+  ansible.builtin.debug:
+    msg: "Hub postflight: {{ 'PASSED' if (__aap_secret_rotate_postflight_hub_ok | bool) else 'FAILED' }}"
+
+- name: Display Hub postflight failures
+  ansible.builtin.debug:
+    msg: |-
+      Hub has encrypted fields that cannot be decrypted with the NEW key:
+      {{ __aap_secret_rotate_postflight_hub_failed_fields | join('\n') }}
+  when: not (__aap_secret_rotate_postflight_hub_ok | bool)
+...

--- a/roles/aap_secret_rotate/tasks/preflight.yml
+++ b/roles/aap_secret_rotate/tasks/preflight.yml
@@ -1,0 +1,217 @@
+---
+- name: Validate requested components
+  ansible.builtin.assert:
+    that:
+      - item in __aap_secret_rotate_components
+    fail_msg: "Unknown component '{{ item }}'. Valid components: {{ __aap_secret_rotate_components.keys() | list }}"
+    quiet: true
+  loop: "{{ aap_secret_rotate_components }}"
+
+- name: Auto-detect deployment type
+  when: aap_secret_rotate_deployment_type | length == 0
+  block:
+    - name: Check for podman binary
+      ansible.builtin.command:
+        cmd: podman --version
+      register: __aap_secret_rotate_podman_check
+      changed_when: false
+      failed_when: false
+
+    - name: Check for podman-based AAP installation
+      ansible.builtin.command:
+        cmd: podman container exists {{ aap_secret_rotate_gateway_container }}
+      register: __aap_secret_rotate_podman_aap_check
+      changed_when: false
+      failed_when: false
+      when: __aap_secret_rotate_podman_check.rc == 0
+
+    - name: Check for kubectl binary
+      ansible.builtin.command:
+        cmd: kubectl version --client
+      register: __aap_secret_rotate_kubectl_check
+      changed_when: false
+      failed_when: false
+      when:
+        - __aap_secret_rotate_podman_check.rc != 0 or (__aap_secret_rotate_podman_aap_check.rc | default(1)) != 0
+
+    - name: Check for oc binary (fallback)
+      ansible.builtin.command:
+        cmd: oc version --client
+      register: __aap_secret_rotate_oc_check
+      changed_when: false
+      failed_when: false
+      when:
+        - __aap_secret_rotate_podman_check.rc != 0 or (__aap_secret_rotate_podman_aap_check.rc | default(1)) != 0
+        - __aap_secret_rotate_kubectl_check.rc | default(1) != 0
+
+    - name: Set deployment type to podman
+      ansible.builtin.set_fact:
+        aap_secret_rotate_deployment_type: "podman"
+      when:
+        - __aap_secret_rotate_podman_check.rc == 0
+        - (__aap_secret_rotate_podman_aap_check.rc | default(1)) == 0
+
+    - name: Set deployment type to operator
+      ansible.builtin.set_fact:
+        aap_secret_rotate_deployment_type: "operator"
+      when:
+        - aap_secret_rotate_deployment_type | length == 0
+        - (__aap_secret_rotate_kubectl_check.rc | default(1) == 0)
+          or (__aap_secret_rotate_oc_check.rc | default(1) == 0)
+
+    - name: Fail if deployment type could not be detected
+      ansible.builtin.fail:
+        msg: >-
+          Could not auto-detect deployment type. No running AAP podman containers
+          found, and neither kubectl nor oc is available. Set
+          aap_secret_rotate_deployment_type explicitly to 'podman' or 'operator'.
+      when: aap_secret_rotate_deployment_type | length == 0
+
+- name: Validate deployment type value
+  ansible.builtin.assert:
+    that:
+      - aap_secret_rotate_deployment_type in ['podman', 'operator']
+    fail_msg: >-
+      aap_secret_rotate_deployment_type must be 'podman' or 'operator',
+      got '{{ aap_secret_rotate_deployment_type }}'
+    quiet: true
+
+- name: Resolve kubectl-compatible CLI binary (operator only)
+  when:
+    - aap_secret_rotate_deployment_type == 'operator'
+    - aap_secret_rotate_kubectl_binary | length == 0
+  block:
+    - name: Probe for kubectl
+      ansible.builtin.command:
+        cmd: kubectl version --client
+      register: __aap_secret_rotate_probe_kubectl
+      changed_when: false
+      failed_when: false
+
+    - name: Probe for oc (fallback)
+      ansible.builtin.command:
+        cmd: oc version --client
+      register: __aap_secret_rotate_probe_oc
+      changed_when: false
+      failed_when: false
+      when: __aap_secret_rotate_probe_kubectl.rc != 0
+
+    - name: Set kubectl binary
+      ansible.builtin.set_fact:
+        aap_secret_rotate_kubectl_binary: >-
+          {{ 'kubectl' if (__aap_secret_rotate_probe_kubectl.rc | default(1)) == 0
+             else 'oc' if (__aap_secret_rotate_probe_oc.rc | default(1)) == 0
+             else '' }}
+
+    - name: Fail if no kubectl-compatible binary found
+      ansible.builtin.fail:
+        msg: >-
+          Neither kubectl nor oc found on this host. Install one or set
+          aap_secret_rotate_kubectl_binary to the path of a compatible CLI.
+      when: aap_secret_rotate_kubectl_binary | length == 0
+
+- name: Detect External Secrets Operator (ESO) and ArgoCD (operator only)
+  when: aap_secret_rotate_deployment_type == 'operator'
+  block:
+    - name: Detect ESO-managed secrets
+      when: aap_secret_rotate_eso_managed | string | length == 0
+      block:
+        - name: Check for ExternalSecret resources targeting AAP secrets
+          kubernetes.core.k8s_info:
+            api_version: external-secrets.io/v1beta1
+            kind: ExternalSecret
+            namespace: "{{ aap_secret_rotate_namespace }}"
+          register: __aap_secret_rotate_eso_check
+          failed_when: false
+
+        - name: Collect ESO-managed secret names
+          ansible.builtin.set_fact:
+            __aap_secret_rotate_eso_managed_secrets: >-
+              {{ __aap_secret_rotate_eso_check.resources | default([])
+                 | map(attribute='spec.target.name', default='')
+                 | select('string')
+                 | list }}
+          when: __aap_secret_rotate_eso_check is not failed
+
+        - name: Set ESO managed flag
+          ansible.builtin.set_fact:
+            aap_secret_rotate_eso_managed: >-
+              {{ (__aap_secret_rotate_eso_managed_secrets | default([]) | length > 0) | bool }}
+
+        - name: Display ESO detection result
+          ansible.builtin.debug:
+            msg: >-
+              External Secrets Operator detected. ESO-managed secrets in namespace:
+              {{ __aap_secret_rotate_eso_managed_secrets | join(', ') }}
+          when: aap_secret_rotate_eso_managed | bool
+
+    - name: Detect ArgoCD-managed Application
+      when:
+        - aap_secret_rotate_argocd_managed | string | length == 0
+          or aap_secret_rotate_argocd_app_namespace | length == 0
+      block:
+        - name: Search for ArgoCD Applications in specific namespace
+          kubernetes.core.k8s_info:
+            api_version: argoproj.io/v1alpha1
+            kind: Application
+            namespace: "{{ aap_secret_rotate_argocd_app_namespace }}"
+          register: __aap_secret_rotate_argocd_apps_check
+          failed_when: false
+          when: aap_secret_rotate_argocd_app_namespace | length > 0
+
+        - name: Search all namespaces for ArgoCD Applications
+          kubernetes.core.k8s_info:
+            api_version: argoproj.io/v1alpha1
+            kind: Application
+          register: __aap_secret_rotate_argocd_apps_check
+          failed_when: false
+          when: aap_secret_rotate_argocd_app_namespace | length == 0
+
+        - name: Find Application managing the AAP namespace
+          ansible.builtin.set_fact:
+            __aap_secret_rotate_argocd_matching_app: >-
+              {{ __aap_secret_rotate_argocd_apps_check.resources | default([])
+                 | selectattr('spec.destination.namespace', 'defined')
+                 | selectattr('spec.destination.namespace', 'equalto', aap_secret_rotate_namespace)
+                 | list | first | default({}) }}
+          when: __aap_secret_rotate_argocd_apps_check is not failed
+
+        - name: Set ArgoCD managed flag, app name, and namespace
+          ansible.builtin.set_fact:
+            aap_secret_rotate_argocd_managed: >-
+              {{ (__aap_secret_rotate_argocd_matching_app | default({}) | length > 0) | bool }}
+            aap_secret_rotate_argocd_app_name: >-
+              {{ __aap_secret_rotate_argocd_matching_app.metadata.name | default('') }}
+            aap_secret_rotate_argocd_app_namespace: >-
+              {{ __aap_secret_rotate_argocd_matching_app.metadata.namespace | default('') }}
+          when:
+            - __aap_secret_rotate_argocd_matching_app | default({}) | length > 0
+
+        - name: Set ArgoCD managed to false when no Application found
+          ansible.builtin.set_fact:
+            aap_secret_rotate_argocd_managed: false
+          when:
+            - __aap_secret_rotate_argocd_matching_app | default({}) | length == 0
+
+        - name: Display ArgoCD detection result
+          ansible.builtin.debug:
+            msg: >-
+              ArgoCD Application '{{ aap_secret_rotate_argocd_app_name }}' detected
+              in namespace '{{ aap_secret_rotate_argocd_app_namespace }}'
+              managing '{{ aap_secret_rotate_namespace }}'.
+          when: aap_secret_rotate_argocd_managed | bool
+
+    - name: Coerce boolean flags for ESO and ArgoCD
+      ansible.builtin.set_fact:
+        aap_secret_rotate_eso_managed: "{{ aap_secret_rotate_eso_managed | default(false) | bool }}"
+        aap_secret_rotate_argocd_managed: "{{ aap_secret_rotate_argocd_managed | default(false) | bool }}"
+
+- name: Display rotation plan
+  ansible.builtin.debug:
+    msg: >-
+      Secret key rotation: components={{ aap_secret_rotate_components | join(', ') }},
+      deployment_type={{ aap_secret_rotate_deployment_type }},
+      dry_run={{ aap_secret_rotate_dry_run }}
+      {{ ', eso_managed=' ~ aap_secret_rotate_eso_managed if aap_secret_rotate_deployment_type == 'operator' else '' }}
+      {{ ', argocd_managed=' ~ aap_secret_rotate_argocd_managed if aap_secret_rotate_deployment_type == 'operator' else '' }}
+...

--- a/roles/aap_secret_rotate/tasks/preflight_check.yml
+++ b/roles/aap_secret_rotate/tasks/preflight_check.yml
@@ -1,0 +1,73 @@
+---
+# Pre-rotation verification orchestrator.
+# Runs component-specific preflight checks to verify all encrypted fields are
+# decryptable with the CURRENT key before attempting rotation.
+#
+# This catches:
+#   - Stale data from previous failed rotations
+#   - Manually modified keys that don't match encrypted data
+#   - Corrupted encrypted fields
+#
+# If any component fails preflight, the play is aborted unless
+# aap_secret_rotate_skip_preflight is set to true.
+
+- name: Display preflight check banner
+  ansible.builtin.debug:
+    msg: |-
+      ╔══════════════════════════════════════════════════════════════════╗
+      ║  Pre-rotation verification: checking all encrypted fields      ║
+      ║  are decryptable with the current key                          ║
+      ╚══════════════════════════════════════════════════════════════════╝
+
+- name: Run Controller preflight check
+  ansible.builtin.include_tasks: preflight_controller.yml
+  when: "'controller' in aap_secret_rotate_components"
+
+- name: Run Gateway preflight check
+  ansible.builtin.include_tasks: preflight_gateway.yml
+  when: "'gateway' in aap_secret_rotate_components"
+
+- name: Run EDA preflight check
+  ansible.builtin.include_tasks: preflight_eda.yml
+  when: "'eda' in aap_secret_rotate_components"
+
+- name: Run Hub preflight check
+  ansible.builtin.include_tasks: preflight_hub.yml
+  when: "'hub' in aap_secret_rotate_components"
+
+- name: Collect preflight results
+  ansible.builtin.set_fact:
+    __aap_secret_rotate_preflight_failures: >-
+      {{
+        ([] if ('controller' not in aap_secret_rotate_components
+                or (__aap_secret_rotate_preflight_controller_ok | default(true) | bool))
+           else ['controller'])
+        + ([] if ('gateway' not in aap_secret_rotate_components
+                  or not (__aap_secret_rotate_gw_has_rotate | default(false) | bool)
+                  or (__aap_secret_rotate_preflight_gateway_ok | default(true) | bool))
+              else ['gateway'])
+        + ([] if ('eda' not in aap_secret_rotate_components
+                  or (__aap_secret_rotate_preflight_eda_ok | default(true) | bool))
+              else ['eda'])
+        + ([] if ('hub' not in aap_secret_rotate_components
+                  or (__aap_secret_rotate_preflight_hub_ok | default(true) | bool))
+              else ['hub'])
+      }}
+
+- name: Display preflight summary
+  ansible.builtin.debug:
+    msg: >-
+      Preflight verification {{ 'PASSED for all components' if
+        (__aap_secret_rotate_preflight_failures | length == 0) else
+        'FAILED for: ' ~ __aap_secret_rotate_preflight_failures | join(', ') }}
+
+- name: Fail if preflight detected undecryptable fields
+  ansible.builtin.fail:
+    msg: >-
+      PREFLIGHT FAILED: The following components have encrypted fields that cannot
+      be decrypted with the current key: {{ __aap_secret_rotate_preflight_failures | join(', ') }}.
+      This indicates stale data from a previous failed rotation or a mismatched key.
+      Resolve these issues before attempting rotation, or set
+      aap_secret_rotate_skip_preflight=true to bypass this check (NOT recommended).
+  when: __aap_secret_rotate_preflight_failures | length > 0
+...

--- a/roles/aap_secret_rotate/tasks/preflight_controller.yml
+++ b/roles/aap_secret_rotate/tasks/preflight_controller.yml
@@ -1,0 +1,61 @@
+---
+# Pre-rotation verification for Automation Controller.
+# Attempts to decrypt all Credential inputs and NotificationTemplate configs
+# using the current SECRET_KEY. Fails if any field is undecryptable (indicating
+# stale data from a previous failed rotation or manual key change).
+
+- name: Run Controller preflight verification
+  ansible.builtin.shell: |
+    {% if aap_secret_rotate_deployment_type == 'podman' %}
+    podman exec {{ __aap_secret_rotate_components.controller.podman_container }} \
+    {% else %}
+    {{ aap_secret_rotate_kubectl_binary }} -n {{ aap_secret_rotate_namespace }} \
+      exec deploy/{{ __aap_secret_rotate_k8s_exec.controller.deployment }} \
+      -c {{ __aap_secret_rotate_k8s_exec.controller.container }} -- \
+    {% endif %}
+      awx-manage shell -c "
+    from awx.main.models import Credential, NotificationTemplate
+    from awx.main.utils.encryption import decrypt_field
+    failed = []
+    for c in Credential.objects.all():
+        for field in c.credential_type.defined_fields:
+            if field in c.inputs:
+                try:
+                    decrypt_field(c, field)
+                except Exception as e:
+                    failed.append(f'Credential({c.pk}).{field}: {e}')
+    for nt in NotificationTemplate.objects.all():
+        try:
+            for key, val in nt.notification_configuration.items():
+                pass
+        except Exception as e:
+            failed.append(f'NotificationTemplate({nt.pk}): {e}')
+    print('PREFLIGHT_FAIL' if failed else 'PREFLIGHT_OK')
+    for f in failed:
+        print(f'  {f}')
+    "
+  args:
+    executable: /bin/bash
+  register: __aap_secret_rotate_preflight_controller_result
+  changed_when: false
+  failed_when: false
+
+- name: Evaluate Controller preflight result
+  ansible.builtin.set_fact:
+    __aap_secret_rotate_preflight_controller_ok: >-
+      {{ 'PREFLIGHT_OK' in (__aap_secret_rotate_preflight_controller_result.stdout | default('')) }}
+    __aap_secret_rotate_preflight_controller_failed_fields: >-
+      {{ __aap_secret_rotate_preflight_controller_result.stdout_lines | default([])
+         | select('match', '^ ') | list }}
+
+- name: Display Controller preflight result
+  ansible.builtin.debug:
+    msg: "Controller preflight: {{ 'PASSED' if (__aap_secret_rotate_preflight_controller_ok | bool) else 'FAILED' }}"
+
+- name: Display Controller preflight failures
+  ansible.builtin.debug:
+    msg: |-
+      Controller has encrypted fields that cannot be decrypted with the current key:
+      {{ __aap_secret_rotate_preflight_controller_failed_fields | join('\n') }}
+  when: not (__aap_secret_rotate_preflight_controller_ok | bool)
+...

--- a/roles/aap_secret_rotate/tasks/preflight_eda.yml
+++ b/roles/aap_secret_rotate/tasks/preflight_eda.yml
@@ -1,0 +1,40 @@
+---
+# Pre-rotation verification for Event-Driven Ansible.
+# Uses the --dry-run flag of rotate_db_encryption_key to check all encrypted
+# fields are decryptable with the current key.
+
+- name: Run EDA preflight dry-run
+  ansible.builtin.command:
+    cmd: >-
+      {% if aap_secret_rotate_deployment_type == 'podman' %}
+      podman exec {{ __aap_secret_rotate_components.eda.podman_container }}
+      {% else %}
+      {{ aap_secret_rotate_kubectl_binary }} -n {{ aap_secret_rotate_namespace }}
+      exec deploy/{{ __aap_secret_rotate_k8s_exec.eda.deployment }}
+      -c {{ __aap_secret_rotate_k8s_exec.eda.container }}
+      --
+      {% endif %}
+      aap-eda-manage rotate_db_encryption_key --dry-run
+  register: __aap_secret_rotate_preflight_eda_result
+  changed_when: false
+  failed_when: false
+
+- name: Evaluate EDA preflight result
+  ansible.builtin.set_fact:
+    __aap_secret_rotate_preflight_eda_ok: >-
+      {{ (__aap_secret_rotate_preflight_eda_result.rc | default(0)) == 0
+         and 'could not be decrypted' not in (__aap_secret_rotate_preflight_eda_result.stdout | default(''))
+         and 'DecryptionError' not in (__aap_secret_rotate_preflight_eda_result.stderr | default('')) }}
+
+- name: Display EDA preflight result
+  ansible.builtin.debug:
+    msg: "EDA preflight: {{ 'PASSED' if (__aap_secret_rotate_preflight_eda_ok | bool) else 'FAILED' }}"
+
+- name: Display EDA preflight errors
+  ansible.builtin.debug:
+    msg: |-
+      EDA has encrypted fields that cannot be decrypted with the current key:
+      stdout: {{ __aap_secret_rotate_preflight_eda_result.stdout | default('') }}
+      stderr: {{ __aap_secret_rotate_preflight_eda_result.stderr | default('') }}
+  when: not (__aap_secret_rotate_preflight_eda_ok | bool)
+...

--- a/roles/aap_secret_rotate/tasks/preflight_gateway.yml
+++ b/roles/aap_secret_rotate/tasks/preflight_gateway.yml
@@ -1,0 +1,106 @@
+---
+# Pre-rotation verification for Automation Gateway.
+# Uses the --dry-run flag of rotate_secret_key to check all encrypted fields
+# are decryptable with the current key.
+#
+# Known issue: AuthenticatorUser.extra_data records may fail decryption due to
+# an upstream bug (jsonb string wrapper preventing $encrypted$ prefix detection).
+# These are handled during rotation by DELETEing the records, so we warn but
+# do not fail the preflight for AuthenticatorUser-only failures.
+
+- name: Check if Gateway has rotate_secret_key command
+  ansible.builtin.command:
+    cmd: >-
+      {% if aap_secret_rotate_deployment_type == 'podman' %}
+      podman exec {{ __aap_secret_rotate_components.gateway.podman_container }}
+      {% else %}
+      {{ aap_secret_rotate_kubectl_binary }} -n {{ aap_secret_rotate_namespace }}
+      exec deploy/{{ __aap_secret_rotate_k8s_exec.gateway.deployment }}
+      -c {{ __aap_secret_rotate_k8s_exec.gateway.container }}
+      --
+      {% endif %}
+      aap-gateway-manage help rotate_secret_key
+  register: __aap_secret_rotate_preflight_gw_cmd_check
+  changed_when: false
+  failed_when: false
+
+- name: Set Gateway preflight availability flag
+  ansible.builtin.set_fact:
+    __aap_secret_rotate_gw_has_rotate: "{{ __aap_secret_rotate_preflight_gw_cmd_check.rc | default(1) == 0 }}"
+
+- name: Skip Gateway preflight when rotate_secret_key is unavailable
+  ansible.builtin.debug:
+    msg: >-
+      Gateway preflight: SKIPPED (rotate_secret_key command not available in this build)
+  when: not (__aap_secret_rotate_gw_has_rotate | bool)
+
+- name: Run Gateway preflight dry-run
+  when: __aap_secret_rotate_gw_has_rotate | bool
+  block:
+    - name: Execute Gateway preflight dry-run
+      ansible.builtin.command:
+        cmd: >-
+          {% if aap_secret_rotate_deployment_type == 'podman' %}
+          podman exec {{ __aap_secret_rotate_components.gateway.podman_container }}
+          {% else %}
+          {{ aap_secret_rotate_kubectl_binary }} -n {{ aap_secret_rotate_namespace }}
+          exec deploy/{{ __aap_secret_rotate_k8s_exec.gateway.deployment }}
+          -c {{ __aap_secret_rotate_k8s_exec.gateway.container }}
+          --
+          {% endif %}
+          aap-gateway-manage rotate_secret_key --dry-run
+      register: __aap_secret_rotate_preflight_gateway_result
+      changed_when: false
+      failed_when: false
+
+    - name: Evaluate Gateway preflight result
+      ansible.builtin.set_fact:
+        __aap_secret_rotate_preflight_gateway_cmd_failed: >-
+          {{ (__aap_secret_rotate_preflight_gateway_result.rc | default(0)) != 0 }}
+        __aap_secret_rotate_preflight_gateway_has_decrypt_errors: >-
+          {{ 'could not be decrypted' in (__aap_secret_rotate_preflight_gateway_result.stdout | default(''))
+             or 'could not be decrypted' in (__aap_secret_rotate_preflight_gateway_result.stderr | default(''))
+             or 'DecryptionError' in (__aap_secret_rotate_preflight_gateway_result.stderr | default('')) }}
+        __aap_secret_rotate_preflight_gateway_au_only: >-
+          {{ ('AuthenticatorUser' in (__aap_secret_rotate_preflight_gateway_result.stderr | default(''))
+              or 'authenticatoruser' in (__aap_secret_rotate_preflight_gateway_result.stderr | default(''))
+              or 'AuthenticatorUser' in (__aap_secret_rotate_preflight_gateway_result.stdout | default(''))
+              or 'authenticatoruser' in (__aap_secret_rotate_preflight_gateway_result.stdout | default('')))
+             and 'ServiceKey' not in (__aap_secret_rotate_preflight_gateway_result.stderr | default(''))
+             and 'Authenticator.' not in (__aap_secret_rotate_preflight_gateway_result.stderr | default(''))
+             and 'Preference' not in (__aap_secret_rotate_preflight_gateway_result.stderr | default('')) }}
+
+    - name: Determine Gateway preflight pass/fail
+      ansible.builtin.set_fact:
+        __aap_secret_rotate_preflight_gateway_ok: >-
+          {{ (not (__aap_secret_rotate_preflight_gateway_cmd_failed | bool)
+              and not (__aap_secret_rotate_preflight_gateway_has_decrypt_errors | bool))
+             or (__aap_secret_rotate_preflight_gateway_au_only | bool) }}
+
+    - name: Display Gateway preflight result
+      ansible.builtin.debug:
+        msg: >-
+          Gateway preflight: {{ 'PASSED' if (__aap_secret_rotate_preflight_gateway_ok | bool) else 'FAILED' }}
+          {{ '(AuthenticatorUser warnings present, handled by rotation workflow)'
+             if (__aap_secret_rotate_preflight_gateway_au_only | bool
+                 and (__aap_secret_rotate_preflight_gateway_has_decrypt_errors | bool))
+             else '' }}
+
+    - name: Display Gateway preflight warnings for AuthenticatorUser
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: Gateway AuthenticatorUser.extra_data records have decryption issues.
+          This is a known upstream bug and will be handled automatically during rotation
+          (records are DELETEd before rotate_secret_key runs). No action required.
+      when:
+        - __aap_secret_rotate_preflight_gateway_au_only | bool
+        - __aap_secret_rotate_preflight_gateway_has_decrypt_errors | bool
+
+    - name: Display Gateway preflight errors
+      ansible.builtin.debug:
+        msg: |-
+          Gateway has encrypted fields that cannot be decrypted with the current key:
+          stdout: {{ __aap_secret_rotate_preflight_gateway_result.stdout | default('') }}
+          stderr: {{ __aap_secret_rotate_preflight_gateway_result.stderr | default('') }}
+      when: not (__aap_secret_rotate_preflight_gateway_ok | bool)
+...

--- a/roles/aap_secret_rotate/tasks/preflight_hub.yml
+++ b/roles/aap_secret_rotate/tasks/preflight_hub.yml
@@ -1,0 +1,62 @@
+---
+# Pre-rotation verification for Automation Hub (Pulp).
+# Hub's rotate-db-key does not support --dry-run, so we verify that all
+# Remote objects (password, proxy_password, token) are readable with the
+# current key by accessing the encrypted property accessors.
+
+- name: Run Hub preflight verification
+  ansible.builtin.shell: |
+    {% if aap_secret_rotate_deployment_type == 'podman' %}
+    podman exec {{ __aap_secret_rotate_components.hub.podman_container }} \
+    {% else %}
+    {{ aap_secret_rotate_kubectl_binary }} -n {{ aap_secret_rotate_namespace }} \
+      exec deploy/{{ __aap_secret_rotate_k8s_exec.hub.deployment }} \
+      -c {{ __aap_secret_rotate_k8s_exec.hub.container }} -- \
+    {% endif %}
+      pulpcore-manager shell -c "
+    from pulpcore.app.models import Remote
+    failed = []
+    for r in Remote.objects.all():
+        try:
+            _ = r.password
+            _ = r.proxy_password
+        except Exception as e:
+            failed.append(f'Remote({r.pk}): {e}')
+    try:
+        from pulp_ansible.app.models import AnsibleRemote
+        for r in AnsibleRemote.objects.all():
+            try:
+                _ = r.token
+            except Exception as e:
+                failed.append(f'AnsibleRemote({r.pk}): {e}')
+    except ImportError:
+        pass
+    print('PREFLIGHT_FAIL' if failed else 'PREFLIGHT_OK')
+    for f in failed:
+        print(f'  {f}')
+    "
+  args:
+    executable: /bin/bash
+  register: __aap_secret_rotate_preflight_hub_result
+  changed_when: false
+  failed_when: false
+
+- name: Evaluate Hub preflight result
+  ansible.builtin.set_fact:
+    __aap_secret_rotate_preflight_hub_ok: >-
+      {{ 'PREFLIGHT_OK' in (__aap_secret_rotate_preflight_hub_result.stdout | default('')) }}
+    __aap_secret_rotate_preflight_hub_failed_fields: >-
+      {{ __aap_secret_rotate_preflight_hub_result.stdout_lines | default([])
+         | select('match', '^ ') | list }}
+
+- name: Display Hub preflight result
+  ansible.builtin.debug:
+    msg: "Hub preflight: {{ 'PASSED' if (__aap_secret_rotate_preflight_hub_ok | bool) else 'FAILED' }}"
+
+- name: Display Hub preflight failures
+  ansible.builtin.debug:
+    msg: |-
+      Hub has encrypted fields that cannot be decrypted with the current key:
+      {{ __aap_secret_rotate_preflight_hub_failed_fields | join('\n') }}
+  when: not (__aap_secret_rotate_preflight_hub_ok | bool)
+...

--- a/roles/aap_secret_rotate/tasks/rotate_controller.yml
+++ b/roles/aap_secret_rotate/tasks/rotate_controller.yml
@@ -1,0 +1,70 @@
+---
+# Rotation workflow for Automation Controller.
+# awx-manage regenerate_secret_key --use-custom-key
+# Env: TOWER_SECRET_KEY=<new_key>
+#
+# Flow:
+# 1. Stop all containers except the exec container
+# 2. Run the rotation command (re-encrypts DB data)
+# 3. Update the podman secret and write the new key into all containers
+# 4. Restart containers so processes load the new key from disk
+
+- name: Set component config for Controller
+  ansible.builtin.set_fact:
+    _component: "controller"
+    _component_config: "{{ __aap_secret_rotate_components.controller }}"
+
+- name: Stop component for Controller (podman only)
+  ansible.builtin.include_tasks: "podman/stop_component.yml"
+  vars:
+    _component: "controller"
+  when: aap_secret_rotate_deployment_type == 'podman'
+
+- name: Start exec container for rotation of Controller (podman)
+  ansible.builtin.command:
+    cmd: "podman start {{ __aap_secret_rotate_components.controller.podman_container }}"
+  changed_when: true
+  when:
+    - aap_secret_rotate_deployment_type == 'podman'
+    - not aap_secret_rotate_dry_run
+
+- name: Wait for exec container to be ready for Controller (podman)
+  ansible.builtin.command:
+    cmd: "podman wait --condition=running {{ __aap_secret_rotate_components.controller.podman_container }}"
+  changed_when: false
+  retries: 6
+  delay: 5
+  register: __aap_secret_rotate_wait_exec
+  until: __aap_secret_rotate_wait_exec.rc == 0
+  when:
+    - aap_secret_rotate_deployment_type == 'podman'
+    - not aap_secret_rotate_dry_run
+
+- name: Run rotation command for Controller
+  ansible.builtin.include_tasks: "{{ aap_secret_rotate_deployment_type }}/exec_command.yml"
+  vars:
+    _component: "controller"
+    _component_config: "{{ __aap_secret_rotate_components.controller }}"
+    _exec_env:
+      TOWER_SECRET_KEY: "{{ __aap_secret_rotate_new_keys.controller }}"
+    _exec_cmd: "awx-manage regenerate_secret_key --use-custom-key"
+
+- name: Write new secret for Controller
+  ansible.builtin.include_tasks: "{{ aap_secret_rotate_deployment_type }}/write_secret.yml"
+  vars:
+    _component: "controller"
+    _component_config: "{{ __aap_secret_rotate_components.controller }}"
+    _secret_value: "{{ __aap_secret_rotate_new_keys.controller }}"
+
+- name: Restart component for Controller (podman only)
+  ansible.builtin.include_tasks: "podman/restart_component.yml"
+  vars:
+    _component: "controller"
+  when: aap_secret_rotate_deployment_type == 'podman'
+
+- name: Rollout restart for Controller (operator only)
+  ansible.builtin.include_tasks: "operator/rollout_restart.yml"
+  vars:
+    _component: "controller"
+  when: aap_secret_rotate_deployment_type == 'operator'
+...

--- a/roles/aap_secret_rotate/tasks/rotate_eda.yml
+++ b/roles/aap_secret_rotate/tasks/rotate_eda.yml
@@ -1,0 +1,167 @@
+---
+# Rotation workflow for Event-Driven Ansible.
+#
+# Key modes:
+#   Custom key provided (aap_secret_rotate_eda_key is set):
+#     Uses --use-custom-key with EDA_SECRET_KEY env var. The command
+#     reads the OLD key from settings (mounted file) and the NEW key
+#     from the env var.
+#
+#     On podman, Dynaconf intercepts EDA_SECRET_KEY and overrides
+#     settings.SECRET_KEY, so we pass the new key via a scratch env
+#     var (_AAP_ROTATE_NEW_KEY) and use a Python wrapper to set
+#     EDA_SECRET_KEY after Dynaconf has loaded, then restore
+#     settings.SECRET_KEY from the on-disk file.
+#
+#   Auto-generated (default, no custom key):
+#     Runs without --use-custom-key. The command generates a new key
+#     internally, re-encrypts data, and prints the new key to stdout.
+#     We capture it and update the secret.
+
+- name: Set component config for EDA
+  ansible.builtin.set_fact:
+    _component: "eda"
+    _component_config: "{{ __aap_secret_rotate_components.eda }}"
+
+- name: Determine EDA key mode
+  ansible.builtin.set_fact:
+    __aap_secret_rotate_eda_use_custom: >-
+      {{ aap_secret_rotate_eda_key | default('') | length > 0 }}
+
+- name: Stop component for EDA (podman only)
+  ansible.builtin.include_tasks: "podman/stop_component.yml"
+  vars:
+    _component: "eda"
+  when: aap_secret_rotate_deployment_type == 'podman'
+
+- name: Start exec container for rotation of EDA (podman)
+  ansible.builtin.command:
+    cmd: "podman start {{ __aap_secret_rotate_components.eda.podman_container }}"
+  changed_when: true
+  when:
+    - aap_secret_rotate_deployment_type == 'podman'
+    - not aap_secret_rotate_dry_run
+
+- name: Wait for exec container to be ready for EDA (podman)
+  ansible.builtin.command:
+    cmd: "podman wait --condition=running {{ __aap_secret_rotate_components.eda.podman_container }}"
+  changed_when: false
+  retries: 6
+  delay: 5
+  register: __aap_secret_rotate_eda_wait
+  until: __aap_secret_rotate_eda_wait.rc == 0
+  when:
+    - aap_secret_rotate_deployment_type == 'podman'
+    - not aap_secret_rotate_dry_run
+
+# Dynaconf workaround: pass the new key through _AAP_ROTATE_NEW_KEY
+# (which Dynaconf ignores because it lacks the EDA_ prefix), then
+# copy it into os.environ["EDA_SECRET_KEY"] and patch
+# settings.SECRET_KEY back to the real old value from the on-disk
+# file before running the management command.
+- name: Run EDA rotation with custom key (podman)
+  ansible.builtin.shell: |
+    podman exec \
+      -e _AAP_ROTATE_NEW_KEY={{ __aap_secret_rotate_new_keys.eda | quote }} \
+      {{ __aap_secret_rotate_components.eda.podman_container }} \
+      python3 -c "
+    import os
+    os.environ['EDA_SECRET_KEY'] = os.environ.pop('_AAP_ROTATE_NEW_KEY')
+    import django; django.setup()
+    from django.conf import settings
+    settings.SECRET_KEY = open('/etc/eda/SECRET_KEY').read().strip()
+    from django.core.management import call_command
+    call_command('rotate_db_encryption_key', use_custom_key=True{{ ', dry_run=True' if aap_secret_rotate_dry_run else '' }})
+    "
+  args:
+    executable: /bin/bash
+  register: __aap_secret_rotate_eda_result
+  changed_when: not aap_secret_rotate_dry_run
+  no_log: true
+  when:
+    - aap_secret_rotate_deployment_type == 'podman'
+    - __aap_secret_rotate_eda_use_custom | bool
+
+- name: Run EDA rotation with auto-generated key (podman)
+  ansible.builtin.command:
+    cmd: >-
+      podman exec
+      {{ __aap_secret_rotate_components.eda.podman_container }}
+      aap-eda-manage rotate_db_encryption_key
+      {{ '--dry-run' if aap_secret_rotate_dry_run else '' }}
+  register: __aap_secret_rotate_eda_result
+  changed_when: not aap_secret_rotate_dry_run
+  when:
+    - aap_secret_rotate_deployment_type == 'podman'
+    - not (__aap_secret_rotate_eda_use_custom | bool)
+
+- name: Run EDA rotation with custom key (operator)
+  ansible.builtin.include_tasks: "operator/exec_command.yml"
+  vars:
+    _component: "eda"
+    _component_config: "{{ __aap_secret_rotate_components.eda }}"
+    _exec_env:
+      EDA_SECRET_KEY: "{{ __aap_secret_rotate_new_keys.eda }}"
+    _exec_cmd: >-
+      aap-eda-manage rotate_db_encryption_key --use-custom-key
+      {{ '--dry-run' if aap_secret_rotate_dry_run else '' }}
+  when:
+    - aap_secret_rotate_deployment_type == 'operator'
+    - __aap_secret_rotate_eda_use_custom | bool
+
+- name: Run EDA rotation with auto-generated key (operator)
+  ansible.builtin.include_tasks: "operator/exec_command.yml"
+  vars:
+    _component: "eda"
+    _component_config: "{{ __aap_secret_rotate_components.eda }}"
+    _exec_env: {}
+    _exec_cmd: >-
+      aap-eda-manage rotate_db_encryption_key
+      {{ '--dry-run' if aap_secret_rotate_dry_run else '' }}
+  when:
+    - aap_secret_rotate_deployment_type == 'operator'
+    - not (__aap_secret_rotate_eda_use_custom | bool)
+
+- name: Set EDA result from exec output (operator)
+  ansible.builtin.set_fact:
+    __aap_secret_rotate_eda_result: "{{ __aap_secret_rotate_exec_result }}"
+  when:
+    - aap_secret_rotate_deployment_type == 'operator'
+    - not aap_secret_rotate_dry_run
+
+- name: Display EDA rotation output
+  ansible.builtin.debug:
+    msg: "{{ __aap_secret_rotate_eda_result.stdout_lines | default([]) }}"
+  when: __aap_secret_rotate_eda_result.stdout_lines | default([]) | length > 0
+
+- name: Capture auto-generated EDA key from command output
+  ansible.builtin.set_fact:
+    __aap_secret_rotate_new_keys: >-
+      {{ __aap_secret_rotate_new_keys | combine({
+           'eda': __aap_secret_rotate_eda_result.stdout_lines[-1] | trim
+         }) }}
+  no_log: true
+  when:
+    - not aap_secret_rotate_dry_run
+    - not (__aap_secret_rotate_eda_use_custom | bool)
+    - __aap_secret_rotate_eda_result.stdout_lines | default([]) | length > 0
+
+- name: Write new secret for EDA
+  ansible.builtin.include_tasks: "{{ aap_secret_rotate_deployment_type }}/write_secret.yml"
+  vars:
+    _component: "eda"
+    _component_config: "{{ __aap_secret_rotate_components.eda }}"
+    _secret_value: "{{ __aap_secret_rotate_new_keys.eda }}"
+
+- name: Restart component for EDA (podman only)
+  ansible.builtin.include_tasks: "podman/restart_component.yml"
+  vars:
+    _component: "eda"
+  when: aap_secret_rotate_deployment_type == 'podman'
+
+- name: Rollout restart for EDA (operator only)
+  ansible.builtin.include_tasks: "operator/rollout_restart.yml"
+  vars:
+    _component: "eda"
+  when: aap_secret_rotate_deployment_type == 'operator'
+...

--- a/roles/aap_secret_rotate/tasks/rotate_gateway.yml
+++ b/roles/aap_secret_rotate/tasks/rotate_gateway.yml
@@ -1,0 +1,256 @@
+---
+# Rotation workflow for Automation Gateway.
+#
+# Gateway stores encrypted data in the database (ServiceKey secrets,
+# Authenticator configuration sub-fields, encrypted Preferences).
+# Re-encrypting this data requires the aap-gateway-manage rotate_secret_key
+# command, which was added in AAP-75712 and ships from the 2.7.20260801+
+# and 2.6.20260801+ builds onward.
+#
+# If the command is not present, Gateway rotation is SKIPPED with a
+# warning. A simple key replacement would leave existing encrypted
+# data unreadable.
+#
+# Known upstream bug: rotate_secret_key reads AuthenticatorUser.extra_data
+# via raw SQL without calling json.loads() on the jsonb column value. The
+# jsonb string wrapper (leading quote) prevents the $encrypted$ prefix
+# from being recognised, causing a decryption failure. As a workaround,
+# this task clears all AuthenticatorUser records before rotation. These
+# records are non-critical auth provider mappings that are automatically
+# recreated on the next user login.
+#
+# Key modes:
+#   Custom key provided (aap_secret_rotate_gateway_key is set):
+#     Uses --use-custom-key with GATEWAY_SECRET_KEY env var.
+#     The command reads the OLD key from settings (mounted file) and the
+#     NEW key from the env var.
+#
+#   Auto-generated (default, no custom key):
+#     Runs without --use-custom-key. The command generates a new key
+#     internally, re-encrypts data, and prints the new key to stdout.
+#     We capture it and update the secret.
+
+- name: Set component config for Gateway
+  ansible.builtin.set_fact:
+    _component: "gateway"
+    _component_config: "{{ __aap_secret_rotate_components.gateway }}"
+
+- name: Check if Gateway has rotate_secret_key command (podman)
+  ansible.builtin.command:
+    cmd: >-
+      podman exec {{ __aap_secret_rotate_components.gateway.podman_container }}
+      aap-gateway-manage help rotate_secret_key
+  register: __aap_secret_rotate_gw_cmd_check
+  changed_when: false
+  failed_when: false
+  when: aap_secret_rotate_deployment_type == 'podman'
+
+- name: Get Gateway deployment selector (operator)
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: "{{ __aap_secret_rotate_k8s_exec.gateway.deployment }}"
+    namespace: "{{ aap_secret_rotate_namespace }}"
+  register: __aap_secret_rotate_gw_deploy
+  when: aap_secret_rotate_deployment_type == 'operator'
+
+- name: Find Gateway pod for command check (operator)
+  ansible.builtin.command:
+    cmd: >-
+      {{ aap_secret_rotate_kubectl_binary }} -n {{ aap_secret_rotate_namespace }}
+      get pods
+      -l {{ __aap_secret_rotate_gw_deploy.resources[0].spec.selector.matchLabels
+            | dict2items | map(attribute='key') | zip(
+              __aap_secret_rotate_gw_deploy.resources[0].spec.selector.matchLabels
+              | dict2items | map(attribute='value')
+            ) | map('join', '=') | join(',') }}
+      --field-selector=status.phase=Running
+      -o jsonpath={.items[0].metadata.name}
+  register: __aap_secret_rotate_gw_pod
+  changed_when: false
+  failed_when: false
+  when:
+    - aap_secret_rotate_deployment_type == 'operator'
+    - __aap_secret_rotate_gw_deploy.resources | length > 0
+
+- name: Check if Gateway has rotate_secret_key command (operator)
+  ansible.builtin.command:
+    cmd: >-
+      {{ aap_secret_rotate_kubectl_binary }} -n {{ aap_secret_rotate_namespace }}
+      exec {{ __aap_secret_rotate_gw_pod.stdout }}
+      -c {{ __aap_secret_rotate_k8s_exec.gateway.container }}
+      -- aap-gateway-manage help rotate_secret_key
+  register: __aap_secret_rotate_gw_cmd_check_operator
+  changed_when: false
+  failed_when: false
+  when:
+    - aap_secret_rotate_deployment_type == 'operator'
+    - __aap_secret_rotate_gw_pod.stdout | default('') | length > 0
+
+- name: Set Gateway rotation mode
+  ansible.builtin.set_fact:
+    __aap_secret_rotate_gw_has_rotate: >-
+      {{ (__aap_secret_rotate_gw_cmd_check.rc | default(1) == 0)
+         or (__aap_secret_rotate_gw_cmd_check_operator.rc | default(1) == 0) }}
+    __aap_secret_rotate_gw_use_custom: "{{ aap_secret_rotate_gateway_key | default('') | length > 0 }}"
+
+- name: Skip Gateway rotation when rotate_secret_key is unavailable
+  when: not (__aap_secret_rotate_gw_has_rotate | bool)
+  block:
+    - name: Display Gateway skip warning
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: Gateway rotation SKIPPED. The rotate_secret_key management
+          command is not available in this Gateway build. Without it, replacing
+          the SECRET_KEY would leave encrypted database fields (ServiceKey
+          secrets, Authenticator configs, Preferences) unreadable. Upgrade
+          Gateway to a build that includes AAP-75712 (2.7.20260801+ or
+          2.6.20260801+) before rotating the Gateway secret key.
+
+- name: Rotate Gateway with management command
+  when: __aap_secret_rotate_gw_has_rotate | bool
+  block:
+    - name: Stop component for Gateway (podman only)
+      ansible.builtin.include_tasks: "podman/stop_component.yml"
+      vars:
+        _component: "gateway"
+      when: aap_secret_rotate_deployment_type == 'podman'
+
+    - name: Start exec container for rotation of Gateway (podman)
+      ansible.builtin.command:
+        cmd: "podman start {{ __aap_secret_rotate_components.gateway.podman_container }}"
+      changed_when: true
+      when:
+        - aap_secret_rotate_deployment_type == 'podman'
+        - not aap_secret_rotate_dry_run
+
+    - name: Wait for exec container to be ready for Gateway (podman)
+      ansible.builtin.command:
+        cmd: "podman wait --condition=running {{ __aap_secret_rotate_components.gateway.podman_container }}"
+      changed_when: false
+      retries: 6
+      delay: 5
+      register: __aap_secret_rotate_gw_wait
+      until: __aap_secret_rotate_gw_wait.rc == 0
+      when:
+        - aap_secret_rotate_deployment_type == 'podman'
+        - not aap_secret_rotate_dry_run
+
+    # Workaround for upstream bug: the rotate_secret_key command reads
+    # AuthenticatorUser.extra_data via raw SQL without deserialising the
+    # jsonb string wrapper, so it cannot decrypt the value even with the
+    # correct key. Clearing these rows before rotation avoids the issue;
+    # they are automatically recreated on next user login.
+    - name: Clear AuthenticatorUser records before rotation (podman)
+      ansible.builtin.command:
+        cmd: >-
+          podman exec {{ __aap_secret_rotate_components.gateway.podman_container }}
+          aap-gateway-manage shell -c
+          "from django.db import connection;
+          c=connection.cursor();
+          c.execute('DELETE FROM dab_authentication_authenticatoruser');
+          print(f'Cleared {c.rowcount} AuthenticatorUser records')"
+      register: __aap_secret_rotate_gw_au_clear
+      changed_when: "'Cleared' in __aap_secret_rotate_gw_au_clear.stdout"
+      when:
+        - aap_secret_rotate_deployment_type == 'podman'
+        - not aap_secret_rotate_dry_run
+
+    - name: Clear AuthenticatorUser records before rotation (operator)
+      ansible.builtin.command:
+        cmd: >-
+          {{ aap_secret_rotate_kubectl_binary }} -n {{ aap_secret_rotate_namespace }}
+          exec {{ __aap_secret_rotate_gw_pod.stdout }}
+          -c {{ __aap_secret_rotate_k8s_exec.gateway.container }}
+          -- aap-gateway-manage shell -c
+          "from django.db import connection;
+          c=connection.cursor();
+          c.execute('DELETE FROM dab_authentication_authenticatoruser');
+          print(f'Cleared {c.rowcount} AuthenticatorUser records')"
+      register: __aap_secret_rotate_gw_au_clear
+      changed_when: "'Cleared' in __aap_secret_rotate_gw_au_clear.stdout"
+      when:
+        - aap_secret_rotate_deployment_type == 'operator'
+        - not aap_secret_rotate_dry_run
+
+    - name: Display AuthenticatorUser cleanup result
+      ansible.builtin.debug:
+        msg: "{{ __aap_secret_rotate_gw_au_clear.stdout_lines | default(['No records to clear']) }}"
+      when: not aap_secret_rotate_dry_run
+
+    - name: Run rotation with custom key for Gateway
+      ansible.builtin.include_tasks: "{{ aap_secret_rotate_deployment_type }}/exec_command.yml"
+      vars:
+        _component: "gateway"
+        _component_config: "{{ __aap_secret_rotate_components.gateway }}"
+        _exec_env:
+          GATEWAY_SECRET_KEY: "{{ __aap_secret_rotate_new_keys.gateway }}"
+        _exec_cmd: >-
+          aap-gateway-manage rotate_secret_key --use-custom-key
+          {{ '--dry-run' if aap_secret_rotate_dry_run else '' }}
+      when: __aap_secret_rotate_gw_use_custom | bool
+
+    - name: Run rotation with auto-generated key for Gateway
+      ansible.builtin.include_tasks: "{{ aap_secret_rotate_deployment_type }}/exec_command.yml"
+      vars:
+        _component: "gateway"
+        _component_config: "{{ __aap_secret_rotate_components.gateway }}"
+        _exec_env: {}
+        _exec_cmd: >-
+          aap-gateway-manage rotate_secret_key
+          {{ '--dry-run' if aap_secret_rotate_dry_run else '' }}
+      when: not (__aap_secret_rotate_gw_use_custom | bool)
+
+    - name: Store Gateway exec result
+      ansible.builtin.set_fact:
+        __aap_secret_rotate_gw_result: "{{ __aap_secret_rotate_exec_result | default({}) }}"
+      when: not aap_secret_rotate_dry_run
+
+    - name: Display Gateway rotation output
+      ansible.builtin.debug:
+        msg: "{{ (__aap_secret_rotate_gw_result | default({})).stdout_lines | default([]) }}"
+      when: (__aap_secret_rotate_gw_result | default({})).stdout_lines | default([]) | length > 0
+
+    - name: Check rotation output for skipped values
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: Gateway rotation reported values that could not be decrypted
+          with the current key. These values were NOT re-encrypted and may need
+          manual remediation. Check the Gateway logs for details.
+      when:
+        - not aap_secret_rotate_dry_run
+        - >-
+          'could not be decrypted' in ((__aap_secret_rotate_gw_result | default({})).stderr | default(''))
+          or 'could not be decrypted' in ((__aap_secret_rotate_gw_result | default({})).stdout | default(''))
+
+    - name: Capture auto-generated Gateway key from command output
+      ansible.builtin.set_fact:
+        __aap_secret_rotate_new_keys: >-
+          {{ __aap_secret_rotate_new_keys | combine({
+               'gateway': __aap_secret_rotate_gw_result.stdout_lines | last | trim
+             }) }}
+      no_log: true
+      when:
+        - not aap_secret_rotate_dry_run
+        - not (__aap_secret_rotate_gw_use_custom | bool)
+        - __aap_secret_rotate_gw_result.stdout_lines | default([]) | length > 0
+
+    - name: Write new secret for Gateway
+      ansible.builtin.include_tasks: "{{ aap_secret_rotate_deployment_type }}/write_secret.yml"
+      vars:
+        _component: "gateway"
+        _component_config: "{{ __aap_secret_rotate_components.gateway }}"
+        _secret_value: "{{ __aap_secret_rotate_new_keys.gateway }}"
+
+    - name: Restart component for Gateway (podman only)
+      ansible.builtin.include_tasks: "podman/restart_component.yml"
+      vars:
+        _component: "gateway"
+      when: aap_secret_rotate_deployment_type == 'podman'
+
+    - name: Rollout restart for Gateway (operator only)
+      ansible.builtin.include_tasks: "operator/rollout_restart.yml"
+      vars:
+        _component: "gateway"
+      when: aap_secret_rotate_deployment_type == 'operator'
+...

--- a/roles/aap_secret_rotate/tasks/rotate_hub.yml
+++ b/roles/aap_secret_rotate/tasks/rotate_hub.yml
@@ -1,0 +1,118 @@
+---
+# Rotation workflow for Automation Hub (Pulp).
+# Hub uses a different mechanism from the other components:
+#   - DB_ENCRYPTION_KEY is a Fernet symmetric key (not Django SECRET_KEY)
+#   - The key file supports multiple keys (one per line)
+#   - First key encrypts, all keys can decrypt
+#   - pulpcore-manager rotate-db-key re-encrypts using the first key
+#
+# Flow:
+# 1. Stop non-exec containers, keep exec container running
+# 2. Write multi-key file (new + old) into exec container
+# 3. Run rotate-db-key (re-encrypts data with new key)
+# 4. Update podman secret and write final key into all containers
+# 5. Restart all containers
+
+- name: Set component config for Hub
+  ansible.builtin.set_fact:
+    _component: "hub"
+    _component_config: "{{ __aap_secret_rotate_components.hub }}"
+
+- name: Store old key for Hub multi-key file
+  ansible.builtin.set_fact:
+    __aap_secret_rotate_hub_old_key: "{{ __aap_secret_rotate_backup_keys.hub }}"
+  no_log: true
+
+- name: Stop component for Hub (podman only)
+  ansible.builtin.include_tasks: "podman/stop_component.yml"
+  vars:
+    _component: "hub"
+  when: aap_secret_rotate_deployment_type == 'podman'
+
+- name: Start exec container for rotation of Hub (podman)
+  ansible.builtin.command:
+    cmd: "podman start {{ __aap_secret_rotate_components.hub.podman_container }}"
+  changed_when: true
+  when:
+    - aap_secret_rotate_deployment_type == 'podman'
+    - not aap_secret_rotate_dry_run
+
+- name: Wait for exec container to be ready for Hub (podman)
+  ansible.builtin.command:
+    cmd: "podman wait --condition=running {{ __aap_secret_rotate_components.hub.podman_container }}"
+  changed_when: false
+  retries: 6
+  delay: 5
+  register: __aap_secret_rotate_hub_wait
+  until: __aap_secret_rotate_hub_wait.rc == 0
+  when:
+    - aap_secret_rotate_deployment_type == 'podman'
+    - not aap_secret_rotate_dry_run
+
+- name: Write multi-key file into exec container for Hub (podman)
+  ansible.builtin.command:
+    cmd: >-
+      podman exec --user 0 {{ __aap_secret_rotate_components.hub.podman_container }}
+      sh -c 'printf "%s\n%s" "$1" "$2" > "$3"'
+      -- "{{ __aap_secret_rotate_new_keys.hub }}"
+      "{{ __aap_secret_rotate_hub_old_key }}"
+      "{{ __aap_secret_rotate_podman_secret_paths.hub }}"
+  no_log: true
+  changed_when: true
+  when:
+    - aap_secret_rotate_deployment_type == 'podman'
+    - not aap_secret_rotate_dry_run
+
+# Operator: write multi-key to K8s Secret, rollout restart Hub so pods
+# mount the file with both keys, then run rotate-db-key.
+- name: Write multi-key to K8s Secret for Hub (operator)
+  kubernetes.core.k8s:
+    state: present
+    definition: |
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: {{ __aap_secret_rotate_components.hub.k8s_secret }}
+        namespace: {{ aap_secret_rotate_namespace }}
+      stringData:
+        {{ __aap_secret_rotate_components.hub.k8s_secret_field }}: {{ (__aap_secret_rotate_new_keys.hub ~ '\n' ~ __aap_secret_rotate_hub_old_key) | to_json }}
+  no_log: true
+  when:
+    - aap_secret_rotate_deployment_type == 'operator'
+    - not aap_secret_rotate_dry_run
+
+- name: Rollout restart Hub to pick up multi-key file (operator)
+  ansible.builtin.include_tasks: "operator/rollout_restart.yml"
+  vars:
+    _component: "hub"
+  when:
+    - aap_secret_rotate_deployment_type == 'operator'
+    - not aap_secret_rotate_dry_run
+
+- name: Run rotation command for Hub
+  ansible.builtin.include_tasks: "{{ aap_secret_rotate_deployment_type }}/exec_command.yml"
+  vars:
+    _component: "hub"
+    _component_config: "{{ __aap_secret_rotate_components.hub }}"
+    _exec_env: {}
+    _exec_cmd: "pulpcore-manager rotate-db-key"
+
+- name: Write final secret for Hub (new key only)
+  ansible.builtin.include_tasks: "{{ aap_secret_rotate_deployment_type }}/write_secret.yml"
+  vars:
+    _component: "hub"
+    _component_config: "{{ __aap_secret_rotate_components.hub }}"
+    _secret_value: "{{ __aap_secret_rotate_new_keys.hub }}"
+
+- name: Restart component for Hub (podman only)
+  ansible.builtin.include_tasks: "podman/restart_component.yml"
+  vars:
+    _component: "hub"
+  when: aap_secret_rotate_deployment_type == 'podman'
+
+- name: Rollout restart Hub with final key (operator)
+  ansible.builtin.include_tasks: "operator/rollout_restart.yml"
+  vars:
+    _component: "hub"
+  when: aap_secret_rotate_deployment_type == 'operator'
+...

--- a/roles/aap_secret_rotate/tasks/verify.yml
+++ b/roles/aap_secret_rotate/tasks/verify.yml
@@ -1,0 +1,44 @@
+---
+# Post-rotation health verification.
+# Checks that the platform is reachable after key rotation.
+
+- name: Verify platform health (podman)
+  when: aap_secret_rotate_deployment_type == 'podman'
+  block:
+    - name: Wait for Gateway to respond
+      ansible.builtin.uri:
+        url: "https://localhost/api/gateway/v1/ping/"
+        validate_certs: false
+        status_code: [200]
+      register: _health_check
+      retries: 30
+      delay: 10
+      until: _health_check.status == 200
+
+    - name: Platform is healthy
+      ansible.builtin.debug:
+        msg: "Gateway API responding: {{ _health_check.json | default('OK') }}"
+
+  rescue:
+    - name: Health check failed (non-fatal)
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: Gateway health check did not succeed within timeout.
+          The platform may still be starting. Check service status manually.
+
+- name: Verify platform health (operator)
+  when: aap_secret_rotate_deployment_type == 'operator'
+  block:
+    - name: Check AAP CR status
+      kubernetes.core.k8s_info:
+        api_version: aap.ansible.com/v1alpha1
+        kind: AnsibleAutomationPlatform
+        name: "{{ aap_secret_rotate_cr_name }}"
+        namespace: "{{ aap_secret_rotate_namespace }}"
+      register: _aap_cr_status
+
+    - name: Display CR conditions
+      ansible.builtin.debug:
+        msg: "AAP CR status: {{ _aap_cr_status.resources[0].status.conditions | default('No conditions yet') }}"
+      when: _aap_cr_status.resources | length > 0
+...

--- a/roles/aap_secret_rotate/tests/test_operator.yml
+++ b/roles/aap_secret_rotate/tests/test_operator.yml
@@ -1,0 +1,36 @@
+---
+# Test playbook: AAP Secret Key Rotation (operator deployment on Kubernetes/OpenShift)
+#
+# Usage:
+#   # Dry run (safe, no changes):
+#   ansible-playbook test_operator.yml -e aap_secret_rotate_dry_run=true
+#
+#   # Full rotation with custom namespace and CR name:
+#   ansible-playbook test_operator.yml \
+#     -e aap_secret_rotate_namespace=my-aap \
+#     -e aap_secret_rotate_cr_name=my-aap
+#
+#   # Single component only:
+#   ansible-playbook test_operator.yml \
+#     -e '{"aap_secret_rotate_components": ["gateway"]}'
+#
+# Prerequisites:
+#   - Back up your AAP database before running without dry_run
+#   - kubectl/oc configured with access to the AAP namespace
+#   - Permissions: Secrets (get/list/patch), Jobs (create/delete),
+#     Deployments (get/list), AnsibleAutomationPlatform CR (get/patch)
+
+- name: AAP Secret Key Rotation (operator)
+  hosts: localhost
+  connection: local
+  gather_facts: true
+
+  vars:
+    aap_secret_rotate_deployment_type: "operator"
+    aap_secret_rotate_namespace: "aap"
+    aap_secret_rotate_cr_name: "aap"
+    aap_secret_rotate_dry_run: true
+
+  roles:
+    - role: infra.aap_utilities.aap_secret_rotate
+...

--- a/roles/aap_secret_rotate/tests/test_podman.yml
+++ b/roles/aap_secret_rotate/tests/test_podman.yml
@@ -1,0 +1,31 @@
+---
+# Test playbook: AAP Secret Key Rotation (podman deployment)
+#
+# Usage:
+#   # Dry run (safe, no changes):
+#   ansible-playbook -i inventory test_podman.yml -e aap_secret_rotate_dry_run=true
+#
+#   # Full rotation:
+#   ansible-playbook -i inventory test_podman.yml
+#
+#   # Single component only:
+#   ansible-playbook -i inventory test_podman.yml \
+#     -e '{"aap_secret_rotate_components": ["controller"]}'
+#
+# Prerequisites:
+#   - Back up your AAP database before running without dry_run
+#   - Target host must have podman and a running AAP 2.7 containerised installation
+#   - SSH access with permissions to manage podman containers and secrets
+
+- name: AAP Secret Key Rotation (podman)
+  hosts: aap
+  gather_facts: true
+  become: true
+
+  vars:
+    aap_secret_rotate_deployment_type: "podman"
+    aap_secret_rotate_dry_run: true
+
+  roles:
+    - role: infra.aap_utilities.aap_secret_rotate
+...

--- a/roles/aap_secret_rotate/tests/vars/test_vars.yml
+++ b/roles/aap_secret_rotate/tests/vars/test_vars.yml
@@ -1,0 +1,18 @@
+---
+# Override variables for testing.
+# Copy and modify as needed for your environment.
+
+# Rotate all components (default order)
+aap_secret_rotate_components:
+  - controller
+  - hub
+  - eda
+  - gateway
+
+# Always start with a dry run
+aap_secret_rotate_dry_run: true
+
+# Operator settings
+aap_secret_rotate_namespace: "aap"
+aap_secret_rotate_cr_name: "aap"
+...

--- a/roles/aap_secret_rotate/vars/main.yml
+++ b/roles/aap_secret_rotate/vars/main.yml
@@ -1,0 +1,128 @@
+---
+# Per-component configuration map.
+# Maps component names to their rotation commands, env vars, and secret names
+# for both podman and operator deployment types.
+#
+# Internal variables are prefixed with double underscore per
+# Automation Good Practices to avoid namespace collisions.
+
+__aap_secret_rotate_components:
+  controller:
+    manage_cmd: "awx-manage"
+    rotate_cmd: "regenerate_secret_key --use-custom-key"
+    env_var: "TOWER_SECRET_KEY"
+    podman_secret: "controller_secret_key"
+    podman_container: "{{ aap_secret_rotate_controller_container }}"
+    k8s_secret: "{{ aap_secret_rotate_cr_name }}-controller-secret-key"
+    k8s_secret_field: "secret_key"
+    k8s_deployment_label: "app.kubernetes.io/component=automationcontroller"
+    custom_key_var: "{{ aap_secret_rotate_controller_key }}"
+    supports_dry_run: false
+
+  gateway:
+    manage_cmd: "aap-gateway-manage"
+    rotate_cmd: "rotate_secret_key --use-custom-key"
+    env_var: "GATEWAY_SECRET_KEY"
+    podman_secret: "gateway_secret_key"
+    podman_container: "{{ aap_secret_rotate_gateway_container }}"
+    k8s_secret: "{{ aap_secret_rotate_cr_name }}-db-fields-encryption-secret"
+    k8s_secret_field: "secret_key"
+    k8s_deployment_label: "app.kubernetes.io/component=aap-gateway"
+    custom_key_var: "{{ aap_secret_rotate_gateway_key }}"
+    supports_dry_run: true
+
+  eda:
+    manage_cmd: "aap-eda-manage"
+    rotate_cmd: "rotate_db_encryption_key --use-custom-key"
+    env_var: "EDA_SECRET_KEY"
+    podman_secret: "eda_secret_key"
+    podman_container: "{{ aap_secret_rotate_eda_container }}"
+    k8s_secret: "{{ aap_secret_rotate_cr_name }}-eda-db-fields-encryption-secret"
+    k8s_secret_field: "secret_key"
+    k8s_deployment_label: "app.kubernetes.io/component=eda-api"
+    custom_key_var: "{{ aap_secret_rotate_eda_key }}"
+    supports_dry_run: true
+
+  hub:
+    manage_cmd: "pulpcore-manager"
+    rotate_cmd: "rotate-db-key"
+    env_var: ""
+    podman_secret: "hub_database_fields"
+    podman_container: "{{ aap_secret_rotate_hub_container }}"
+    k8s_secret: "{{ aap_secret_rotate_cr_name }}-hub-db-fields-encryption"
+    k8s_secret_field: "database_fields.symmetric.key"
+    k8s_deployment_label: "app.kubernetes.io/component=api,app.kubernetes.io/part-of=automationhub"
+    custom_key_var: "{{ aap_secret_rotate_hub_key }}"
+    supports_dry_run: false
+
+__aap_secret_rotate_podman_containers:
+  controller:
+    - "automation-controller-task"
+    - "automation-controller-web"
+  gateway:
+    - "automation-gateway"
+  eda:
+    - "automation-eda-api"
+    - "automation-eda-daphne"
+    - "automation-eda-web"
+    - "automation-eda-worker-1"
+    - "automation-eda-worker-2"
+    - "automation-eda-activation-worker-1"
+    - "automation-eda-activation-worker-2"
+  hub:
+    - "automation-hub-api"
+    - "automation-hub-content"
+    - "automation-hub-web"
+    - "automation-hub-worker-1"
+    - "automation-hub-worker-2"
+
+# In-container paths where each component's secret key file is mounted.
+# After updating the podman secret, we also overwrite this file inside
+# every running container so the process picks up the new key without
+# needing the container to be recreated.
+__aap_secret_rotate_podman_secret_paths:
+  controller: "/etc/tower/SECRET_KEY"
+  gateway: "/etc/ansible-automation-platform/gateway/SECRET_KEY"
+  eda: "/etc/eda/SECRET_KEY"
+  hub: "/etc/pulp/keys/database_fields.symmetric.key"
+
+# Kubernetes exec targets: the deployment and container to exec into for
+# running management commands on each component.
+__aap_secret_rotate_k8s_exec:
+  controller:
+    deployment: "{{ aap_secret_rotate_cr_name }}-controller-task"
+    container: "{{ aap_secret_rotate_cr_name }}-controller-task"
+  gateway:
+    deployment: "{{ aap_secret_rotate_cr_name }}-gateway"
+    container: "api"
+  eda:
+    deployment: "{{ aap_secret_rotate_cr_name }}-eda-api"
+    container: "eda-api"
+  hub:
+    deployment: "{{ aap_secret_rotate_cr_name }}-hub-api"
+    container: "api"
+
+# All Kubernetes deployments per component that need a rollout restart
+# after the secret key is updated.
+__aap_secret_rotate_k8s_deployments:
+  controller:
+    - "{{ aap_secret_rotate_cr_name }}-controller-task"
+    - "{{ aap_secret_rotate_cr_name }}-controller-web"
+  gateway:
+    - "{{ aap_secret_rotate_cr_name }}-gateway"
+  eda:
+    - "{{ aap_secret_rotate_cr_name }}-eda-api"
+    - "{{ aap_secret_rotate_cr_name }}-eda-activation-worker"
+    - "{{ aap_secret_rotate_cr_name }}-eda-default-worker"
+    - "{{ aap_secret_rotate_cr_name }}-eda-event-stream"
+  hub:
+    - "{{ aap_secret_rotate_cr_name }}-hub-api"
+    - "{{ aap_secret_rotate_cr_name }}-hub-content"
+    - "{{ aap_secret_rotate_cr_name }}-hub-worker"
+    - "{{ aap_secret_rotate_cr_name }}-hub-web"
+
+# In-container key file paths for operator deployments (same paths as
+# Podman but used for multi-key writes via kubectl exec).
+__aap_secret_rotate_k8s_secret_paths:
+  hub: "/etc/pulp/keys/database_fields.symmetric.key"
+...


### PR DESCRIPTION
# What does this PR do?

Adds a new `aap_secret_rotate` role that automates the rotation of database encryption keys (`SECRET_KEY`) for all AAP 2.7 components: Controller, Gateway, EDA, and Hub.

**Supports both deployment types:**
- **Podman** (containerised installer): stops containers, runs rotation commands via `podman exec`, replaces podman secrets (including in-container file updates), restarts services
- **Operator** (Kubernetes/OpenShift): idles the AAP CR, execs into pods, patches K8s Secrets, rollout restarts deployments

**Key features:**
- Full 4-component rotation with proper ordering (Gateway last to minimise session disruption)
- Kubernetes-agnostic: works on OpenShift, AKS, EKS, and vanilla Kubernetes
- Auto-detection of External Secrets Operator (ESO) and ArgoCD with pause/resume support for enterprise GitOps environments
- Pre-flight and post-flight verification that all encrypted database fields are decryptable before and after rotation
- Custom key support (user-provided) and auto-generated Fernet-compatible keys
- Dry-run mode for safe previewing
- Hub multi-key file handling for zero-downtime rotation
- Workaround for upstream Gateway bug where `AuthenticatorUser.extra_data` records cause decryption failures during `rotate_secret_key` (records are cleared before rotation and auto-recreated on next user login)
- Dynaconf workaround for EDA custom keys on Podman (passes the key via a scratch env var to avoid Dynaconf intercepting `EDA_SECRET_KEY`)
- Adds `containers.podman` collection dependency to `galaxy.yml`

# How should this be tested?

## Dry run (safe, read-only)

```yaml
- name: Dry run rotation
  hosts: aap
  roles:
    - role: infra.aap_utilities.aap_secret_rotate
      aap_secret_rotate_dry_run: true
```

## Full rotation (podman)

```yaml
- name: Rotate all keys
  hosts: aap
  roles:
    - role: infra.aap_utilities.aap_secret_rotate
      aap_secret_rotate_deployment_type: podman
```

## Full rotation (operator)

```yaml
- name: Rotate all keys
  hosts: localhost
  connection: local
  roles:
    - role: infra.aap_utilities.aap_secret_rotate
      aap_secret_rotate_deployment_type: operator
      aap_secret_rotate_namespace: my-aap
      aap_secret_rotate_cr_name: my-aap
```

**Verification after rotation:**
1. All component APIs respond (Gateway ping, Controller credentials API, EDA API, Hub API)
2. Admin and non-admin users can authenticate through Gateway
3. All Controller credentials decrypt correctly (`awx-manage shell -c "..."`)
4. Gateway ServiceKey secrets are accessible
5. Hub Remote passwords/tokens are accessible

**E2E test results:**
- Operator (OpenShift, AAP 2.7.4): 3 consecutive clean runs, all passed
- Podman (AWS EC2, RHEL 9.6, AAP 2.7): full rotation passed with all preflight/postflight checks
- External database (CNPG PostgreSQL): rotation passed

# Is there a relevant Issue open for this?

No existing issue. This addresses a common Day 2 operations requirement for AAP deployments where periodic SECRET_KEY rotation is needed for security compliance.

# Other Relevant info, PRs, etc

- **Gateway `rotate_secret_key` command**: Shipped in AAP 2.7.4+ (upstream: [ansible/jewel#52](https://github.com/ansible/jewel/pull/52), Jira: AAP-75712). The role dynamically detects its presence and skips Gateway rotation with a warning on older builds.
- **Gateway `AuthenticatorUser.extra_data` bug**: The `rotate_secret_key` command reads `AuthenticatorUser.extra_data` via raw SQL without deserialising the jsonb wrapper, causing spurious decryption failures. The upstream fix has been [merged](https://github.com/ansible/jewel/pull/202) and will be backported and released soon. Until then, this role includes a workaround (clearing the records before rotation; they are auto-recreated on next user login).