### PR TITLE
feat: Add aap_password_rotate role for DB and admin password rotation

### DIFF
--- a/changelogs/fragments/aap_password_rotate-new-role.yml
+++ b/changelogs/fragments/aap_password_rotate-new-role.yml
@@ -1,0 +1,8 @@
+---
+major_changes:
+  - >-
+    aap_password_rotate - new role to rotate PostgreSQL database passwords
+    and admin user passwords across all AAP 2.7 components (controller,
+    gateway, hub, EDA). Supports Podman (via installer re-run) and Operator
+    (via K8s secret patching) deployment types, with optional external
+    database handling through a user-provided hook tasks file.

--- a/roles/aap_password_rotate/README.md
+++ b/roles/aap_password_rotate/README.md
@@ -1,0 +1,222 @@
+# aap_password_rotate
+
+Rotates PostgreSQL database passwords and admin user passwords across all Ansible Automation Platform 2.7 components: Controller, Gateway, Event-Driven Ansible (EDA), and Automation Hub.
+
+Supports both **podman** (containerised installer) and **operator** (Kubernetes/OpenShift) deployments, with both **installer-managed** and **external** databases.
+
+> This role complements the `aap_secret_rotate` role, which handles SECRET_KEY (encryption key) rotation. These are two separate operations: password rotation changes authentication credentials, while secret rotation changes the keys used to encrypt database fields.
+
+## Requirements
+
+- Ansible >= 2.15
+- AAP 2.7 (tested on 2.7.2 and 2.7.4)
+- For podman: SSH access to the AAP host with podman permissions
+- For operator: `kubectl` or `oc` with cluster-admin or namespace-scoped permissions
+- For external DB: no special requirements (the role pauses or runs a user-provided hook)
+
+## What Gets Rotated
+
+### Database Passwords
+
+| Component | DB User | Inventory Variable |
+|---|---|---|
+| Controller | `awx` | `controller_pg_password` |
+| Gateway | `gateway` | `gateway_pg_password` |
+| EDA | `eda` | `eda_pg_password` |
+| Hub | `pulp` | `hub_pg_password` |
+| PostgreSQL superuser | `postgres` | `postgresql_admin_password` |
+
+### Admin User Passwords
+
+| Component | Management Command |
+|---|---|
+| Gateway | `aap-gateway-manage changepassword admin` |
+| Controller | `awx-manage changepassword admin` |
+| Hub | `pulpcore-manager reset-admin-password` |
+| EDA | `aap-eda-manage update_password --username admin --password <pw>` |
+
+## How It Works
+
+### Podman (via installer, recommended)
+
+Per [KCS 7145426](https://access.redhat.com/solutions/7145426), the containerised installer natively supports password rotation:
+
+1. If rotating the postgres superuser: `ALTER ROLE postgres` first
+2. Update the inventory file with new `*_pg_password` values
+3. Re-run the installer (handles ALTER ROLE for component users, updates podman secrets, restarts containers)
+4. Rotate admin passwords via management commands
+
+### Podman (manual, for external DB)
+
+When the installer cannot reach the external database:
+
+1. `ALTER ROLE` for each component DB user directly on the external PostgreSQL
+2. Update podman secrets
+3. Restart component containers
+4. Rotate admin passwords via management commands
+
+### Operator
+
+1. `ALTER ROLE` for each component via exec into the PG pod (internal DB), or pause/hook for user action (external DB)
+2. Patch Kubernetes `postgres-configuration` Secrets with new passwords
+3. Rollout restart all component Deployments
+4. Rotate admin passwords via exec into component pods
+5. Patch `admin-password` Secrets to keep them in sync (per KCS 7144197)
+
+## Usage
+
+### Dry run (safe, read-only)
+
+```yaml
+- name: Dry run password rotation
+  hosts: aap
+  roles:
+    - role: infra.aap_utilities.aap_password_rotate
+      aap_password_rotate_dry_run: true
+```
+
+### Full rotation, podman (DB + admin passwords)
+
+```yaml
+- name: Rotate all passwords
+  hosts: aap
+  roles:
+    - role: infra.aap_utilities.aap_password_rotate
+      aap_password_rotate_deployment_type: podman
+      aap_password_rotate_scope:
+        - db
+        - admin
+      aap_password_rotate_include_postgres_admin: true
+      aap_password_rotate_podman_use_installer: true
+```
+
+### DB passwords only, operator
+
+```yaml
+- name: Rotate DB passwords
+  hosts: localhost
+  connection: local
+  roles:
+    - role: infra.aap_utilities.aap_password_rotate
+      aap_password_rotate_deployment_type: operator
+      aap_password_rotate_namespace: my-aap
+      aap_password_rotate_cr_name: my-aap
+      aap_password_rotate_scope:
+        - db
+```
+
+### Custom passwords
+
+```yaml
+- name: Rotate with specific passwords
+  hosts: aap
+  roles:
+    - role: infra.aap_utilities.aap_password_rotate
+      aap_password_rotate_deployment_type: podman
+      aap_password_rotate_controller_pg_password: "MyNewCtrlPw-2026!"
+      aap_password_rotate_gateway_pg_password: "MyNewGwPw-2026!"
+      aap_password_rotate_eda_pg_password: "MyNewEdaPw-2026!"
+      aap_password_rotate_hub_pg_password: "MyNewHubPw-2026!"
+```
+
+### External database (interactive)
+
+When `external_db: true`, the role generates new passwords, writes `ALTER ROLE` SQL
+to a helper file, and pauses for you to apply the SQL on your external database.
+After you confirm, the role patches application secrets and restarts services.
+
+```yaml
+- name: Rotate with external DB (interactive pause)
+  hosts: localhost
+  connection: local
+  roles:
+    - role: infra.aap_utilities.aap_password_rotate
+      aap_password_rotate_deployment_type: operator
+      aap_password_rotate_namespace: my-aap
+      aap_password_rotate_cr_name: my-aap
+      aap_password_rotate_external_db: true
+```
+
+### External database (custom hook)
+
+If you want to automate the external DB password change, provide your own tasks
+file via `aap_password_rotate_external_db_tasks`. The role calls `include_tasks`
+on it instead of pausing. Your tasks file receives these variables:
+
+| Variable | Type | Description |
+|---|---|---|
+| `aap_password_rotate_components` | list | Components being rotated (e.g. `[controller, hub, eda, gateway]`) |
+| `__pw_db_users` | dict | Component to DB username (e.g. `{controller: automationcontroller}`) |
+| `__pw_db_passwords` | dict | Component to new password |
+| `__pw_postgres_admin_password` | str | New postgres superuser password (when `include_postgres_admin: true`) |
+
+Example hook for AWS RDS:
+
+```yaml
+# my_rds_password_rotate.yml
+- name: Update RDS password for each component
+  amazon.aws.rds_instance:
+    db_instance_identifier: "aap-{{ item }}"
+    master_user_password: "{{ __pw_db_passwords[item] }}"
+  loop: "{{ aap_password_rotate_components }}"
+  no_log: true
+```
+
+Example hook using `psql` on a bastion host:
+
+```yaml
+# my_bastion_alter_role.yml
+- name: ALTER ROLE via psql on bastion
+  ansible.builtin.command:
+    cmd: >-
+      psql -h {{ my_pg_host }} -U postgres -c
+      "ALTER ROLE {{ __pw_db_users[item] }} WITH PASSWORD '{{ __pw_db_passwords[item] }}';"
+  loop: "{{ aap_password_rotate_components }}"
+  delegate_to: bastion
+  no_log: true
+```
+
+Playbook using the hook:
+
+```yaml
+- name: Rotate with external DB (automated via hook)
+  hosts: localhost
+  connection: local
+  roles:
+    - role: infra.aap_utilities.aap_password_rotate
+      aap_password_rotate_deployment_type: operator
+      aap_password_rotate_namespace: my-aap
+      aap_password_rotate_cr_name: my-aap
+      aap_password_rotate_external_db: true
+      aap_password_rotate_external_db_tasks: "{{ playbook_dir }}/my_rds_password_rotate.yml"
+```
+
+## Role Variables
+
+See [`defaults/main.yml`](defaults/main.yml) for all configurable variables and [`meta/argument_specs.yml`](meta/argument_specs.yml) for full documentation.
+
+## Verification
+
+After rotation, the role automatically verifies:
+
+1. Gateway ping responds (HTTP 200)
+2. Admin authentication works with the new password
+3. Controller, Hub, and EDA APIs respond
+4. DB connectivity with new passwords (podman only)
+
+## Related
+
+- `aap_secret_rotate`: Rotates SECRET_KEY (encryption keys) across AAP components
+- [KCS 7145426](https://access.redhat.com/solutions/7145426): How to rotate PostgreSQL database passwords in AAP 2.7 Containerized
+- [KCS 7100528](https://access.redhat.com/solutions/7100528): How to change PostgreSQL Database password of gateway
+- [KCS 6746191](https://access.redhat.com/solutions/6746191): How to change Admin and PostgreSQL Database Passwords (AAP 2.4 and earlier)
+- [KCS 7130353](https://access.redhat.com/solutions/7130353): How to change Automation Gateway Admin Password on AAP 2.5
+- [KCS 7144197](https://access.redhat.com/solutions/7144197): How to find auto-generated passwords in AAP
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+Alexey Masolov (@amasolov), Red Hat

--- a/roles/aap_password_rotate/README.md
+++ b/roles/aap_password_rotate/README.md
@@ -19,7 +19,7 @@ Supports both **podman** (containerised installer) and **operator** (Kubernetes/
 ### Database Passwords
 
 | Component | DB User | Inventory Variable |
-|---|---|---|
+| --- | --- | --- |
 | Controller | `awx` | `controller_pg_password` |
 | Gateway | `gateway` | `gateway_pg_password` |
 | EDA | `eda` | `eda_pg_password` |
@@ -29,7 +29,7 @@ Supports both **podman** (containerised installer) and **operator** (Kubernetes/
 ### Admin User Passwords
 
 | Component | Management Command |
-|---|---|
+| --- | --- |
 | Gateway | `aap-gateway-manage changepassword admin` |
 | Controller | `awx-manage changepassword admin` |
 | Hub | `pulpcore-manager reset-admin-password` |
@@ -144,7 +144,7 @@ file via `aap_password_rotate_external_db_tasks`. The role calls `include_tasks`
 on it instead of pausing. Your tasks file receives these variables:
 
 | Variable | Type | Description |
-|---|---|---|
+| --- | --- | --- |
 | `aap_password_rotate_components` | list | Components being rotated (e.g. `[controller, hub, eda, gateway]`) |
 | `__pw_db_users` | dict | Component to DB username (e.g. `{controller: automationcontroller}`) |
 | `__pw_db_passwords` | dict | Component to new password |

--- a/roles/aap_password_rotate/README.md
+++ b/roles/aap_password_rotate/README.md
@@ -28,12 +28,16 @@ Supports both **podman** (containerised installer) and **operator** (Kubernetes/
 
 ### Admin User Passwords
 
-| Component | Management Command |
+| Component | Method |
 | --- | --- |
-| Gateway | `aap-gateway-manage changepassword admin` |
-| Controller | `awx-manage changepassword admin` |
-| Hub | `pulpcore-manager reset-admin-password` |
+| Gateway | Django shell via `aap-gateway-manage shell` (`get_user_model().set_password`) |
+| Controller | Django shell via `awx-manage shell` (`get_user_model().set_password`) |
+| Hub | `pulpcore-manager reset-admin-password --password <pw>` |
 | EDA | `aap-eda-manage update_password --username admin --password <pw>` |
+
+> **Note:** Gateway and Controller use the Django ORM directly instead of the
+> interactive `changepassword` command, which requires a TTY that is not
+> available inside `podman exec` or `kubectl exec` contexts.
 
 ## How It Works
 

--- a/roles/aap_password_rotate/defaults/main.yml
+++ b/roles/aap_password_rotate/defaults/main.yml
@@ -1,0 +1,98 @@
+---
+# Deployment type: "podman" or "operator" (auto-detected if omitted)
+aap_password_rotate_deployment_type: ""
+
+# What to rotate: "db", "admin", or both
+aap_password_rotate_scope:
+  - db
+  - admin
+
+# Components to rotate (order: Gateway last for session continuity)
+aap_password_rotate_components:
+  - controller
+  - hub
+  - eda
+  - gateway
+
+# Dry run: report what would change without writing
+aap_password_rotate_dry_run: false
+
+# Backup directory for current passwords (on the control node)
+aap_password_rotate_backup_dir: "{{ playbook_dir }}/password_backups/{{ ansible_date_time.date | default(lookup('pipe', 'date +%Y-%m-%d')) }}"
+
+# Custom passwords (empty = auto-generate a 24-char random password)
+aap_password_rotate_controller_pg_password: ""
+aap_password_rotate_gateway_pg_password: ""
+aap_password_rotate_eda_pg_password: ""
+aap_password_rotate_hub_pg_password: ""
+aap_password_rotate_postgres_admin_password: ""
+
+# Whether to rotate the postgresql_admin_password (postgres superuser)
+aap_password_rotate_include_postgres_admin: false
+
+# Admin user passwords (empty = auto-generate)
+aap_password_rotate_gateway_admin_password: ""
+aap_password_rotate_controller_admin_password: ""
+aap_password_rotate_hub_admin_password: ""
+aap_password_rotate_eda_admin_password: ""
+
+# Password generation settings
+aap_password_rotate_password_length: 24
+aap_password_rotate_password_chars: "ascii_letters,digits"
+
+# ── Podman-specific ────────────────────────────────────────────────────
+# Path to the containerised installer inventory file
+aap_password_rotate_installer_inventory: ""
+
+# Path to the containerised installer directory (contains ansible.containerized_installer)
+aap_password_rotate_installer_dir: ""
+
+# Whether to re-run the installer for DB password rotation (recommended).
+# If false, the role does manual ALTER ROLE + podman secret update + restart.
+aap_password_rotate_podman_use_installer: true
+
+# Container names (defaults match AAP 2.7 containerised installer)
+aap_password_rotate_controller_container: "automation-controller-task"
+aap_password_rotate_gateway_container: "automation-gateway"
+aap_password_rotate_eda_container: "automation-eda-api"
+aap_password_rotate_hub_container: "automation-hub-api"
+aap_password_rotate_pg_container: "postgresql"
+
+# Podman systemd service scope
+aap_password_rotate_systemd_scope: "user"
+
+# ── Operator-specific ──────────────────────────────────────────────────
+aap_password_rotate_namespace: "aap"
+aap_password_rotate_cr_name: "aap"
+aap_password_rotate_rollout_timeout: 300
+
+# Path to the kubectl-compatible CLI binary (auto-detected if empty)
+aap_password_rotate_kubectl_binary: ""
+
+# ── External database ─────────────────────────────────────────────────
+# Set to true when the database is external (not managed by the installer/operator).
+# When true, the role generates ALTER ROLE SQL, writes it to a helper file,
+# and pauses for the user to run the SQL on their external database manually.
+# After the user confirms, the role proceeds to update application secrets
+# and restart services.
+aap_password_rotate_external_db: false
+
+# Skip the interactive pause (for non-interactive/CI usage).
+# When true (and external_db is true), the role assumes ALTER ROLE has already
+# been applied and proceeds directly to patching secrets and restarting.
+aap_password_rotate_external_db_no_pause: false
+
+# Path to a custom tasks file for external DB password changes.
+# When set (and external_db is true), the role includes this file
+# instead of pausing. The tasks receive password variables and are
+# expected to apply ALTER ROLE or equivalent on the external DB.
+# If empty, the role falls back to the pause-and-show-SQL flow.
+#
+# Available variables inside the hook:
+#   aap_password_rotate_components  - list of components being rotated
+#   __pw_db_users                   - dict: component -> DB username
+#   __pw_db_passwords               - dict: component -> new password
+#   __pw_postgres_admin_password    - new postgres superuser password
+#                                     (only when include_postgres_admin is true)
+aap_password_rotate_external_db_tasks: ""
+...

--- a/roles/aap_password_rotate/meta/argument_specs.yml
+++ b/roles/aap_password_rotate/meta/argument_specs.yml
@@ -1,0 +1,149 @@
+---
+argument_specs:
+  main:
+    short_description: Rotate passwords across AAP 2.7 components
+    description:
+      - Rotates PostgreSQL database passwords and admin user passwords for
+        Ansible Automation Platform 2.7 components.
+      - Supports both podman (containerised installer) and operator
+        (Kubernetes/OpenShift) deployments.
+      - For podman deployments, leverages the containerised installer for
+        DB password rotation (recommended) or can perform manual rotation.
+      - For operator deployments, performs ALTER ROLE in PostgreSQL, patches
+        K8s Secrets, and triggers rollout restarts.
+      - Covers Automation Controller, Gateway, Event-Driven Ansible, and
+        Automation Hub.
+    options:
+      aap_password_rotate_deployment_type:
+        description: Deployment type. Auto-detected if empty.
+        type: str
+        choices:
+          - podman
+          - operator
+          - ""
+        default: ""
+      aap_password_rotate_scope:
+        description: >-
+          What to rotate. Use "db" for database passwords, "admin" for
+          admin user passwords, or both.
+        type: list
+        elements: str
+        default:
+          - db
+          - admin
+      aap_password_rotate_components:
+        description: List of components to rotate. Order matters.
+        type: list
+        elements: str
+        default:
+          - controller
+          - hub
+          - eda
+          - gateway
+      aap_password_rotate_dry_run:
+        description: Report what would change without writing.
+        type: bool
+        default: false
+      aap_password_rotate_backup_dir:
+        description: Directory on the control node for password backups.
+        type: str
+      aap_password_rotate_include_postgres_admin:
+        description: >-
+          Whether to also rotate the postgres superuser password.
+          Requires manual ALTER ROLE first on podman deployments.
+        type: bool
+        default: false
+      aap_password_rotate_controller_pg_password:
+        description: Custom DB password for Controller. Auto-generated if empty.
+        type: str
+        default: ""
+      aap_password_rotate_gateway_pg_password:
+        description: Custom DB password for Gateway. Auto-generated if empty.
+        type: str
+        default: ""
+      aap_password_rotate_eda_pg_password:
+        description: Custom DB password for EDA. Auto-generated if empty.
+        type: str
+        default: ""
+      aap_password_rotate_hub_pg_password:
+        description: Custom DB password for Hub. Auto-generated if empty.
+        type: str
+        default: ""
+      aap_password_rotate_postgres_admin_password:
+        description: Custom password for postgres superuser. Auto-generated if empty.
+        type: str
+        default: ""
+      aap_password_rotate_gateway_admin_password:
+        description: Custom admin password for Gateway. Auto-generated if empty.
+        type: str
+        default: ""
+      aap_password_rotate_controller_admin_password:
+        description: Custom admin password for Controller. Auto-generated if empty.
+        type: str
+        default: ""
+      aap_password_rotate_hub_admin_password:
+        description: Custom admin password for Hub. Auto-generated if empty.
+        type: str
+        default: ""
+      aap_password_rotate_eda_admin_password:
+        description: Custom admin password for EDA. Auto-generated if empty.
+        type: str
+        default: ""
+      aap_password_rotate_installer_inventory:
+        description: >-
+          Path to the containerised installer inventory file (podman only).
+          Required when using installer-based rotation.
+        type: str
+        default: ""
+      aap_password_rotate_installer_dir:
+        description: >-
+          Path to the containerised installer directory (podman only).
+          Required when using installer-based rotation.
+        type: str
+        default: ""
+      aap_password_rotate_podman_use_installer:
+        description: >-
+          Whether to use the containerised installer for DB password
+          rotation on podman. Recommended. If false, performs manual
+          ALTER ROLE + config update + restart.
+        type: bool
+        default: true
+      aap_password_rotate_namespace:
+        description: Kubernetes namespace (operator deployments).
+        type: str
+        default: aap
+      aap_password_rotate_cr_name:
+        description: AnsibleAutomationPlatform CR name (operator deployments).
+        type: str
+        default: aap
+      aap_password_rotate_external_db:
+        description: >-
+          Whether the database is external (not managed by the
+          installer/operator). When true, the role generates ALTER ROLE
+          SQL, writes it to a helper file, and pauses for the user to
+          run the SQL on their external database manually.
+        type: bool
+        default: false
+      aap_password_rotate_external_db_no_pause:
+        description: >-
+          Skip the interactive pause when external_db is true. For
+          non-interactive or CI usage where ALTER ROLE has already been
+          applied before invoking the role.
+        type: bool
+        default: false
+      aap_password_rotate_external_db_tasks:
+        description: >-
+          Path to a custom Ansible tasks file for external DB password
+          changes. When set (and external_db is true), the role includes
+          this file instead of pausing. The tasks receive
+          aap_password_rotate_components, __pw_db_users,
+          __pw_db_passwords, and __pw_postgres_admin_password as
+          variables and should apply ALTER ROLE or equivalent.
+        type: str
+        default: ""
+      aap_password_rotate_kubectl_binary:
+        description: >-
+          Path to a kubectl-compatible CLI binary. Auto-detected if empty.
+        type: str
+        default: ""
+...

--- a/roles/aap_password_rotate/meta/main.yml
+++ b/roles/aap_password_rotate/meta/main.yml
@@ -1,0 +1,23 @@
+---
+galaxy_info:
+  author: Alexey Masolov
+  description: Rotate PostgreSQL database and admin user passwords across AAP 2.7 components
+  company: Red Hat
+
+  license: GPL-3.0-or-later
+
+  min_ansible_version: "2.15"
+
+  platforms:
+    - name: EL
+      versions:
+        - "9"
+
+  galaxy_tags:
+    - aap
+    - security
+    - password
+    - rotation
+
+dependencies: []
+...

--- a/roles/aap_password_rotate/tasks/backup_passwords.yml
+++ b/roles/aap_password_rotate/tasks/backup_passwords.yml
@@ -1,0 +1,49 @@
+---
+- name: Ensure backup directory exists
+  ansible.builtin.file:
+    path: "{{ aap_password_rotate_backup_dir }}"
+    state: directory
+    mode: "0700"
+  delegate_to: "{{ 'localhost' if aap_password_rotate_deployment_type == 'operator' else omit }}"
+
+- name: Build backup content
+  ansible.builtin.set_fact:
+    __pw_backup_content: |
+      # AAP Password Backup
+      # Generated: {{ ansible_date_time.iso8601 | default(lookup('pipe', 'date -u +%Y-%m-%dT%H:%M:%SZ')) }}
+      # Deployment type: {{ aap_password_rotate_deployment_type }}
+      # Scope: {{ aap_password_rotate_scope | join(', ') }}
+      #
+      # These are the NEW passwords set during this rotation.
+      # Keep this file secure.
+      {% if 'db' in aap_password_rotate_scope %}
+
+      [db_passwords]
+      {% for comp in aap_password_rotate_components %}
+      {{ comp }}_pg_password={{ __pw_db_passwords[comp] }}
+      {% endfor %}
+      {% if aap_password_rotate_include_postgres_admin | bool %}
+      postgresql_admin_password={{ __pw_postgres_admin_password }}
+      {% endif %}
+      {% endif %}
+      {% if 'admin' in aap_password_rotate_scope %}
+
+      [admin_passwords]
+      {% for comp in aap_password_rotate_components %}
+      {{ comp }}_admin_password={{ __pw_admin_passwords[comp] }}
+      {% endfor %}
+      {% endif %}
+  no_log: true
+
+- name: Write backup file
+  ansible.builtin.copy:
+    content: "{{ __pw_backup_content }}"
+    dest: "{{ aap_password_rotate_backup_dir }}/aap_passwords.bak"
+    mode: "0600"
+  no_log: true
+  delegate_to: "{{ 'localhost' if aap_password_rotate_deployment_type == 'operator' else omit }}"
+
+- name: Backup saved
+  ansible.builtin.debug:
+    msg: "New passwords saved to {{ aap_password_rotate_backup_dir }}/aap_passwords.bak"
+...

--- a/roles/aap_password_rotate/tasks/external_db_pause.yml
+++ b/roles/aap_password_rotate/tasks/external_db_pause.yml
@@ -1,0 +1,70 @@
+---
+# External DB password change handler.
+# Included by operator/rotate_db.yml and podman/rotate_db_manual.yml
+# when aap_password_rotate_external_db is true.
+#
+# Three modes (checked in order):
+#   1. Hook tasks file provided -> include it (user handles ALTER ROLE)
+#   2. no_pause is true         -> skip (user already ran ALTER ROLE)
+#   3. Default                  -> display SQL, write helper file, pause
+
+# ── Mode 1: User-provided hook tasks ─────────────────────────────────
+- name: Run external DB hook tasks
+  ansible.builtin.include_tasks: "{{ aap_password_rotate_external_db_tasks }}"
+  when: aap_password_rotate_external_db_tasks | length > 0
+
+# ── Mode 2 & 3: Generate SQL helper (always useful as a reference) ────
+- name: Write ALTER ROLE helper script
+  ansible.builtin.copy:
+    content: |
+      -- ALTER ROLE statements for AAP password rotation
+      -- Generated: {{ ansible_date_time.iso8601 | default(lookup('pipe', 'date -u +%Y-%m-%dT%H:%M:%SZ')) }}
+      -- Run these on your external PostgreSQL database.
+
+      {% for comp in aap_password_rotate_components %}
+      ALTER ROLE {{ __pw_db_users[comp] }} WITH PASSWORD '{{ __pw_db_passwords[comp] }}';
+      {% endfor %}
+      {% if aap_password_rotate_include_postgres_admin | bool %}
+
+      -- Postgres superuser
+      ALTER ROLE postgres WITH PASSWORD '{{ __pw_postgres_admin_password }}';
+      {% endif %}
+    dest: "{{ aap_password_rotate_backup_dir }}/alter_role.sql"
+    mode: "0600"
+  no_log: true
+  when: aap_password_rotate_external_db_tasks | length == 0
+
+# ── Mode 3: Interactive pause ─────────────────────────────────────────
+- name: Display instructions
+  ansible.builtin.debug:
+    msg: |
+      ════════════════════════════════════════════════════════════════════════
+        EXTERNAL DATABASE: Manual password change required
+
+        Run the SQL statements from this file on your external PostgreSQL:
+        {{ aap_password_rotate_backup_dir }}/alter_role.sql
+
+        Components to update:
+      {% for comp in aap_password_rotate_components %}
+          - {{ comp }} (user: {{ __pw_db_users[comp] }})
+      {% endfor %}
+      {% if aap_password_rotate_include_postgres_admin | bool %}
+          - postgres (superuser)
+      {% endif %}
+
+        After running the SQL, press ENTER to continue.
+        The role will then update application secrets and restart services.
+      ════════════════════════════════════════════════════════════════════════
+  when:
+    - aap_password_rotate_external_db_tasks | length == 0
+    - not (aap_password_rotate_external_db_no_pause | default(false) | bool)
+
+- name: Wait for user to complete ALTER ROLE on external database
+  ansible.builtin.pause:
+    prompt: >-
+      ALTER ROLE SQL saved to {{ aap_password_rotate_backup_dir }}/alter_role.sql.
+      Run it on your external database, then press ENTER to continue
+  when:
+    - aap_password_rotate_external_db_tasks | length == 0
+    - not (aap_password_rotate_external_db_no_pause | default(false) | bool)
+...

--- a/roles/aap_password_rotate/tasks/generate_passwords.yml
+++ b/roles/aap_password_rotate/tasks/generate_passwords.yml
@@ -1,0 +1,115 @@
+---
+# Generate new passwords for all components in scope.
+# Uses user-provided passwords if set, otherwise auto-generates.
+
+- name: Generate DB passwords
+  when: "'db' in aap_password_rotate_scope"
+  block:
+    - name: Generate controller DB password
+      ansible.builtin.set_fact:
+        __pw_controller_pg_password: >-
+          {{ aap_password_rotate_controller_pg_password
+             if aap_password_rotate_controller_pg_password | length > 0
+             else lookup('ansible.builtin.password', '/dev/null length=' ~ aap_password_rotate_password_length ~ ' chars=' ~ aap_password_rotate_password_chars) }}
+      no_log: true
+      when: "'controller' in aap_password_rotate_components"
+
+    - name: Generate gateway DB password
+      ansible.builtin.set_fact:
+        __pw_gateway_pg_password: >-
+          {{ aap_password_rotate_gateway_pg_password
+             if aap_password_rotate_gateway_pg_password | length > 0
+             else lookup('ansible.builtin.password', '/dev/null length=' ~ aap_password_rotate_password_length ~ ' chars=' ~ aap_password_rotate_password_chars) }}
+      no_log: true
+      when: "'gateway' in aap_password_rotate_components"
+
+    - name: Generate EDA DB password
+      ansible.builtin.set_fact:
+        __pw_eda_pg_password: >-
+          {{ aap_password_rotate_eda_pg_password
+             if aap_password_rotate_eda_pg_password | length > 0
+             else lookup('ansible.builtin.password', '/dev/null length=' ~ aap_password_rotate_password_length ~ ' chars=' ~ aap_password_rotate_password_chars) }}
+      no_log: true
+      when: "'eda' in aap_password_rotate_components"
+
+    - name: Generate hub DB password
+      ansible.builtin.set_fact:
+        __pw_hub_pg_password: >-
+          {{ aap_password_rotate_hub_pg_password
+             if aap_password_rotate_hub_pg_password | length > 0
+             else lookup('ansible.builtin.password', '/dev/null length=' ~ aap_password_rotate_password_length ~ ' chars=' ~ aap_password_rotate_password_chars) }}
+      no_log: true
+      when: "'hub' in aap_password_rotate_components"
+
+    - name: Generate postgres admin password
+      ansible.builtin.set_fact:
+        __pw_postgres_admin_password: >-
+          {{ aap_password_rotate_postgres_admin_password
+             if aap_password_rotate_postgres_admin_password | length > 0
+             else lookup('ansible.builtin.password', '/dev/null length=' ~ aap_password_rotate_password_length ~ ' chars=' ~ aap_password_rotate_password_chars) }}
+      no_log: true
+      when: aap_password_rotate_include_postgres_admin | bool
+
+    - name: Build DB password map
+      ansible.builtin.set_fact:
+        __pw_db_passwords: >-
+          {{ __pw_db_passwords | default({}) | combine({
+               item: lookup('vars', '__pw_' ~ item ~ '_pg_password')
+             }) }}
+      loop: "{{ aap_password_rotate_components }}"
+      no_log: true
+
+- name: Generate admin passwords
+  when: "'admin' in aap_password_rotate_scope"
+  block:
+    - name: Generate gateway admin password
+      ansible.builtin.set_fact:
+        __pw_gateway_admin_password: >-
+          {{ aap_password_rotate_gateway_admin_password
+             if aap_password_rotate_gateway_admin_password | length > 0
+             else lookup('ansible.builtin.password', '/dev/null length=' ~ aap_password_rotate_password_length ~ ' chars=' ~ aap_password_rotate_password_chars) }}
+      no_log: true
+      when: "'gateway' in aap_password_rotate_components"
+
+    - name: Generate controller admin password
+      ansible.builtin.set_fact:
+        __pw_controller_admin_password: >-
+          {{ aap_password_rotate_controller_admin_password
+             if aap_password_rotate_controller_admin_password | length > 0
+             else lookup('ansible.builtin.password', '/dev/null length=' ~ aap_password_rotate_password_length ~ ' chars=' ~ aap_password_rotate_password_chars) }}
+      no_log: true
+      when: "'controller' in aap_password_rotate_components"
+
+    - name: Generate hub admin password
+      ansible.builtin.set_fact:
+        __pw_hub_admin_password: >-
+          {{ aap_password_rotate_hub_admin_password
+             if aap_password_rotate_hub_admin_password | length > 0
+             else lookup('ansible.builtin.password', '/dev/null length=' ~ aap_password_rotate_password_length ~ ' chars=' ~ aap_password_rotate_password_chars) }}
+      no_log: true
+      when: "'hub' in aap_password_rotate_components"
+
+    - name: Generate EDA admin password
+      ansible.builtin.set_fact:
+        __pw_eda_admin_password: >-
+          {{ aap_password_rotate_eda_admin_password
+             if aap_password_rotate_eda_admin_password | length > 0
+             else lookup('ansible.builtin.password', '/dev/null length=' ~ aap_password_rotate_password_length ~ ' chars=' ~ aap_password_rotate_password_chars) }}
+      no_log: true
+      when: "'eda' in aap_password_rotate_components"
+
+    - name: Build admin password map
+      ansible.builtin.set_fact:
+        __pw_admin_passwords: >-
+          {{ __pw_admin_passwords | default({}) | combine({
+               item: lookup('vars', '__pw_' ~ item ~ '_admin_password')
+             }) }}
+      loop: "{{ aap_password_rotate_components }}"
+      no_log: true
+
+- name: Passwords generated
+  ansible.builtin.debug:
+    msg: >-
+      Generated passwords for {{ aap_password_rotate_scope | join(' and ') }}
+      rotation across {{ aap_password_rotate_components | join(', ') }}.
+...

--- a/roles/aap_password_rotate/tasks/main.yml
+++ b/roles/aap_password_rotate/tasks/main.yml
@@ -1,0 +1,97 @@
+---
+# AAP Password Rotation Orchestrator
+#
+# Prerequisites:
+#   - Database backup completed BEFORE running this role
+#   - For podman: SSH access to the AAP host with podman permissions
+#     and access to the containerised installer directory/inventory
+#   - For operator: kubectl/oc access to the Kubernetes cluster with
+#     permissions to read/write Secrets, exec into pods, and rollout
+#     restart Deployments
+
+- name: Preflight checks
+  ansible.builtin.include_tasks: preflight.yml
+
+- name: Generate new passwords
+  ansible.builtin.include_tasks: generate_passwords.yml
+
+- name: Back up current passwords
+  ansible.builtin.include_tasks: backup_passwords.yml
+  when: not aap_password_rotate_dry_run
+
+# ── Database password rotation ────────────────────────────────────────
+- name: Rotate database passwords (podman via installer)
+  ansible.builtin.include_tasks: podman/rotate_db.yml
+  when:
+    - "'db' in aap_password_rotate_scope"
+    - aap_password_rotate_deployment_type == 'podman'
+    - aap_password_rotate_podman_use_installer | bool
+    - not aap_password_rotate_external_db
+    - not aap_password_rotate_dry_run
+
+- name: Rotate database passwords (podman manual / external DB)
+  ansible.builtin.include_tasks: podman/rotate_db_manual.yml
+  when:
+    - "'db' in aap_password_rotate_scope"
+    - aap_password_rotate_deployment_type == 'podman'
+    - (not (aap_password_rotate_podman_use_installer | bool)) or aap_password_rotate_external_db
+    - not aap_password_rotate_dry_run
+
+- name: Rotate database passwords (operator)
+  ansible.builtin.include_tasks: operator/rotate_db.yml
+  when:
+    - "'db' in aap_password_rotate_scope"
+    - aap_password_rotate_deployment_type == 'operator'
+    - not aap_password_rotate_dry_run
+
+# ── Admin password rotation ──────────────────────────────────────────
+- name: Rotate admin passwords (podman)
+  ansible.builtin.include_tasks: podman/rotate_admin.yml
+  when:
+    - "'admin' in aap_password_rotate_scope"
+    - aap_password_rotate_deployment_type == 'podman'
+    - not aap_password_rotate_dry_run
+
+- name: Rotate admin passwords (operator)
+  ansible.builtin.include_tasks: operator/rotate_admin.yml
+  when:
+    - "'admin' in aap_password_rotate_scope"
+    - aap_password_rotate_deployment_type == 'operator'
+    - not aap_password_rotate_dry_run
+
+# ── Verify and report ────────────────────────────────────────────────
+- name: Verify platform health
+  ansible.builtin.include_tasks: verify.yml
+  when: not aap_password_rotate_dry_run
+
+- name: Display dry run summary
+  ansible.builtin.debug:
+    msg: |
+      ╔══════════════════════════════════════════════════════════════════╗
+      ║  DRY RUN: Password Rotation Plan                               ║
+      ╠══════════════════════════════════════════════════════════════════╣
+      ║  Deployment type: {{ aap_password_rotate_deployment_type }}
+      ║  Scope: {{ aap_password_rotate_scope | join(', ') }}
+      ║  Components: {{ aap_password_rotate_components | join(', ') }}
+      ║  Include postgres admin: {{ aap_password_rotate_include_postgres_admin }}
+      ║  External DB: {{ aap_password_rotate_external_db }}
+      {% if aap_password_rotate_deployment_type == 'podman' %}
+      ║  Use installer: {{ aap_password_rotate_podman_use_installer }}
+      ║  Installer dir: {{ aap_password_rotate_installer_dir | default('not set') }}
+      ║  Inventory: {{ aap_password_rotate_installer_inventory | default('not set') }}
+      {% endif %}
+      {% if aap_password_rotate_deployment_type == 'operator' %}
+      ║  Namespace: {{ aap_password_rotate_namespace }}
+      ║  CR name: {{ aap_password_rotate_cr_name }}
+      {% endif %}
+      ╚══════════════════════════════════════════════════════════════════╝
+  when: aap_password_rotate_dry_run
+
+- name: Rotation complete
+  ansible.builtin.debug:
+    msg: >-
+      Password rotation {{ 'DRY RUN ' if aap_password_rotate_dry_run else '' }}complete.
+      Scope: {{ aap_password_rotate_scope | join(', ') }}.
+      Components: {{ aap_password_rotate_components | join(', ') }}.
+      Backup saved to: {{ aap_password_rotate_backup_dir }}/aap_passwords.bak
+...

--- a/roles/aap_password_rotate/tasks/operator/alter_role.yml
+++ b/roles/aap_password_rotate/tasks/operator/alter_role.yml
@@ -3,7 +3,7 @@
 # Uses the username read from the K8s postgres-configuration secret
 # (stored in __pw_db_users map), not a hardcoded value.
 
-- name: "ALTER ROLE {{ __pw_db_users[__pw_component] }} via PG pod ({{ __pw_component }})"
+- name: "ALTER ROLE via PG pod - {{ __pw_component }}"
   ansible.builtin.command:
     cmd: >-
       {{ aap_password_rotate_kubectl_binary }} -n {{ aap_password_rotate_namespace }}

--- a/roles/aap_password_rotate/tasks/operator/alter_role.yml
+++ b/roles/aap_password_rotate/tasks/operator/alter_role.yml
@@ -1,0 +1,15 @@
+---
+# ALTER ROLE for a single component's DB user on operator deployments (internal DB).
+# Uses the username read from the K8s postgres-configuration secret
+# (stored in __pw_db_users map), not a hardcoded value.
+
+- name: "ALTER ROLE {{ __pw_db_users[__pw_component] }} via PG pod ({{ __pw_component }})"
+  ansible.builtin.command:
+    cmd: >-
+      {{ aap_password_rotate_kubectl_binary }} -n {{ aap_password_rotate_namespace }}
+      exec {{ __pw_pg_exec_pod }} --
+      psql -U postgres -c
+      "ALTER ROLE {{ __pw_db_users[__pw_component] }} WITH PASSWORD '{{ __pw_db_passwords[__pw_component] }}';"
+  no_log: true
+  changed_when: true
+...

--- a/roles/aap_password_rotate/tasks/operator/alter_role_postgres.yml
+++ b/roles/aap_password_rotate/tasks/operator/alter_role_postgres.yml
@@ -1,0 +1,24 @@
+---
+# ALTER ROLE for the postgres superuser on operator deployments (internal DB).
+
+- name: ALTER ROLE postgres via PG pod
+  ansible.builtin.command:
+    cmd: >-
+      {{ aap_password_rotate_kubectl_binary }} -n {{ aap_password_rotate_namespace }}
+      exec {{ __pw_pg_exec_pod }} --
+      psql -U postgres -c
+      "ALTER ROLE postgres WITH PASSWORD '{{ __pw_postgres_admin_password }}';"
+  no_log: true
+  changed_when: true
+
+- name: Verify new postgres password
+  ansible.builtin.command:
+    cmd: >-
+      {{ aap_password_rotate_kubectl_binary }} -n {{ aap_password_rotate_namespace }}
+      exec {{ __pw_pg_exec_pod }} --
+      psql -h localhost -U postgres -c "SELECT 1;"
+  environment:
+    PGPASSWORD: "{{ __pw_postgres_admin_password }}"
+  no_log: true
+  changed_when: false
+...

--- a/roles/aap_password_rotate/tasks/operator/change_admin_password.yml
+++ b/roles/aap_password_rotate/tasks/operator/change_admin_password.yml
@@ -2,7 +2,7 @@
 # Change admin password for a single component on operator deployments.
 # Called in a loop from rotate_admin.yml.
 
-- name: "Find {{ __pw_component }} pod via deployment"
+- name: "Find pod via deployment - {{ __pw_component }}"
   ansible.builtin.shell:
     cmd: >-
       {{ aap_password_rotate_kubectl_binary }} -n {{ aap_password_rotate_namespace }}
@@ -15,7 +15,7 @@
   changed_when: false
 
 # EDA uses a non-interactive command with the password as an argument
-- name: "Change {{ __pw_component }} admin password (EDA)"
+- name: "Change admin password (EDA) - {{ __pw_component }}"
   ansible.builtin.command:
     cmd: >-
       {{ aap_password_rotate_kubectl_binary }} -n {{ aap_password_rotate_namespace }}
@@ -32,7 +32,7 @@
 # Gateway and Controller: use Django shell with get_user_model() to avoid
 # model-swapping issues (gateway uses aap_gateway_api.User) and
 # getpass EOFError in non-TTY exec contexts.
-- name: "Change {{ __pw_component }} admin password (Gateway/Controller)"
+- name: "Change admin password (Gateway/Controller) - {{ __pw_component }}"
   ansible.builtin.shell:
     cmd: >-
       {{ aap_password_rotate_kubectl_binary }} -n {{ aap_password_rotate_namespace }}
@@ -51,7 +51,7 @@
   when: __pw_component in ['gateway', 'controller']
 
 # Hub: pulpcore-manager reset-admin-password accepts --password flag
-- name: "Change {{ __pw_component }} admin password (Hub)"
+- name: "Change admin password (Hub) - {{ __pw_component }}"
   ansible.builtin.command:
     cmd: >-
       {{ aap_password_rotate_kubectl_binary }} -n {{ aap_password_rotate_namespace }}

--- a/roles/aap_password_rotate/tasks/operator/change_admin_password.yml
+++ b/roles/aap_password_rotate/tasks/operator/change_admin_password.yml
@@ -1,0 +1,66 @@
+---
+# Change admin password for a single component on operator deployments.
+# Called in a loop from rotate_admin.yml.
+
+- name: "Find {{ __pw_component }} pod via deployment"
+  ansible.builtin.shell:
+    cmd: >-
+      {{ aap_password_rotate_kubectl_binary }} -n {{ aap_password_rotate_namespace }}
+      get pods
+      -l app.kubernetes.io/component={{ __aap_password_rotate_k8s_exec[__pw_component].label_component }}
+      --field-selector=status.phase=Running
+      -o jsonpath='{.items[0].metadata.name}'
+    executable: /bin/bash
+  register: __pw_admin_pod
+  changed_when: false
+
+# EDA uses a non-interactive command with the password as an argument
+- name: "Change {{ __pw_component }} admin password (EDA)"
+  ansible.builtin.command:
+    cmd: >-
+      {{ aap_password_rotate_kubectl_binary }} -n {{ aap_password_rotate_namespace }}
+      exec {{ __pw_admin_pod.stdout }}
+      -c {{ __aap_password_rotate_k8s_exec[__pw_component].container }} --
+      {{ __aap_password_rotate_admin_config[__pw_component].manage_cmd }}
+      {{ __aap_password_rotate_admin_config[__pw_component].change_cmd }}
+      {{ __aap_password_rotate_admin_config[__pw_component].change_args }}
+      {{ __pw_admin_passwords[__pw_component] }}
+  no_log: true
+  changed_when: true
+  when: __pw_component == 'eda'
+
+# Gateway and Controller: use Django shell with get_user_model() to avoid
+# model-swapping issues (gateway uses aap_gateway_api.User) and
+# getpass EOFError in non-TTY exec contexts.
+- name: "Change {{ __pw_component }} admin password (Gateway/Controller)"
+  ansible.builtin.shell:
+    cmd: >-
+      {{ aap_password_rotate_kubectl_binary }} -n {{ aap_password_rotate_namespace }}
+      exec {{ __pw_admin_pod.stdout }}
+      -c {{ __aap_password_rotate_k8s_exec[__pw_component].container }} --
+      {{ __aap_password_rotate_admin_config[__pw_component].manage_cmd }} shell -c
+      "from django.contrib.auth import get_user_model;
+      User = get_user_model();
+      u = User.objects.get(username='admin');
+      u.set_password('{{ __pw_admin_passwords[__pw_component] }}');
+      u.save();
+      print('password changed')"
+    executable: /bin/bash
+  no_log: true
+  changed_when: true
+  when: __pw_component in ['gateway', 'controller']
+
+# Hub: pulpcore-manager reset-admin-password accepts --password flag
+- name: "Change {{ __pw_component }} admin password (Hub)"
+  ansible.builtin.command:
+    cmd: >-
+      {{ aap_password_rotate_kubectl_binary }} -n {{ aap_password_rotate_namespace }}
+      exec {{ __pw_admin_pod.stdout }}
+      -c {{ __aap_password_rotate_k8s_exec[__pw_component].container }} --
+      {{ __aap_password_rotate_admin_config[__pw_component].manage_cmd }}
+      {{ __aap_password_rotate_admin_config[__pw_component].change_cmd }}
+      --password {{ __pw_admin_passwords[__pw_component] }}
+  no_log: true
+  changed_when: true
+  when: __pw_component == 'hub'
+...

--- a/roles/aap_password_rotate/tasks/operator/rollout_restart.yml
+++ b/roles/aap_password_rotate/tasks/operator/rollout_restart.yml
@@ -2,7 +2,7 @@
 # Rollout restart all deployments for a single component.
 # Called in a loop from rotate_db.yml and rotate_admin.yml.
 
-- name: "Rollout restart {{ __pw_component }} deployments"
+- name: "Rollout restart deployments - {{ __pw_component }}"
   ansible.builtin.command:
     cmd: >-
       {{ aap_password_rotate_kubectl_binary }} -n {{ aap_password_rotate_namespace }}
@@ -11,7 +11,7 @@
   changed_when: true
   failed_when: false
 
-- name: "Wait for {{ __pw_component }} rollout"
+- name: "Wait for rollout - {{ __pw_component }}"
   ansible.builtin.command:
     cmd: >-
       {{ aap_password_rotate_kubectl_binary }} -n {{ aap_password_rotate_namespace }}
@@ -22,7 +22,7 @@
   register: __pw_rollout_status
   failed_when: false
 
-- name: "Check {{ __pw_component }} rollout result"
+- name: "Check rollout result - {{ __pw_component }}"
   ansible.builtin.debug:
     msg: >-
       {{ item.item }}: {{ 'OK' if item.rc == 0 else 'TIMEOUT/FAIL (rc=' ~ item.rc ~ ')' }}

--- a/roles/aap_password_rotate/tasks/operator/rollout_restart.yml
+++ b/roles/aap_password_rotate/tasks/operator/rollout_restart.yml
@@ -1,0 +1,32 @@
+---
+# Rollout restart all deployments for a single component.
+# Called in a loop from rotate_db.yml and rotate_admin.yml.
+
+- name: "Rollout restart {{ __pw_component }} deployments"
+  ansible.builtin.command:
+    cmd: >-
+      {{ aap_password_rotate_kubectl_binary }} -n {{ aap_password_rotate_namespace }}
+      rollout restart deployment/{{ item }}
+  loop: "{{ __aap_password_rotate_k8s_deployments[__pw_component] }}"
+  changed_when: true
+  failed_when: false
+
+- name: "Wait for {{ __pw_component }} rollout"
+  ansible.builtin.command:
+    cmd: >-
+      {{ aap_password_rotate_kubectl_binary }} -n {{ aap_password_rotate_namespace }}
+      rollout status deployment/{{ item }}
+      --timeout={{ aap_password_rotate_rollout_timeout }}s
+  loop: "{{ __aap_password_rotate_k8s_deployments[__pw_component] }}"
+  changed_when: false
+  register: __pw_rollout_status
+  failed_when: false
+
+- name: "Check {{ __pw_component }} rollout result"
+  ansible.builtin.debug:
+    msg: >-
+      {{ item.item }}: {{ 'OK' if item.rc == 0 else 'TIMEOUT/FAIL (rc=' ~ item.rc ~ ')' }}
+  loop: "{{ __pw_rollout_status.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+...

--- a/roles/aap_password_rotate/tasks/operator/rotate_admin.yml
+++ b/roles/aap_password_rotate/tasks/operator/rotate_admin.yml
@@ -1,0 +1,26 @@
+---
+# Rotate admin user passwords on operator deployments.
+# Uses kubectl exec to run management commands in component pods,
+# then patches the K8s admin-password secrets.
+
+- name: Rotate admin passwords for each component
+  ansible.builtin.include_tasks: operator/change_admin_password.yml
+  loop: "{{ aap_password_rotate_components }}"
+  loop_control:
+    loop_var: __pw_component
+
+# Patch K8s admin-password secrets to match the new passwords.
+# These secrets are informational (not used for auth) but should
+# be kept in sync for DR and operational purposes (see KCS 7144197).
+- name: Patch admin-password secrets
+  ansible.builtin.command:
+    cmd: >-
+      {{ aap_password_rotate_kubectl_binary }} -n {{ aap_password_rotate_namespace }}
+      patch secret {{ __aap_password_rotate_admin_config[item].k8s_secret }}
+      --type merge
+      -p '{"data":{"{{ __aap_password_rotate_admin_config[item].k8s_secret_field }}":"{{ __pw_admin_passwords[item] | b64encode }}"}}'
+  loop: "{{ aap_password_rotate_components }}"
+  no_log: true
+  changed_when: true
+  failed_when: false
+...

--- a/roles/aap_password_rotate/tasks/operator/rotate_db.yml
+++ b/roles/aap_password_rotate/tasks/operator/rotate_db.yml
@@ -1,0 +1,93 @@
+---
+# Operator DB password rotation.
+#
+# For each component:
+#   1. Read current PG config from the K8s postgres-configuration secret
+#      (including the actual username, which varies by deployment)
+#   2. ALTER ROLE in PostgreSQL:
+#      - Internal DB: exec into the PG pod automatically
+#      - External DB: pause and let the user run ALTER ROLE manually
+#   3. Patch the K8s postgres-configuration secret with the new password
+#   4. Rollout restart all deployments for that component
+
+# ── Read current PG connection details ──────────────────────────────
+- name: Read PostgreSQL configuration secrets
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: "{{ __aap_password_rotate_db_config[item].k8s_secret }}"
+    namespace: "{{ aap_password_rotate_namespace }}"
+  loop: "{{ aap_password_rotate_components }}"
+  register: __pw_pg_secrets
+  no_log: true
+
+- name: Build DB user map from secrets
+  ansible.builtin.set_fact:
+    __pw_db_users: >-
+      {{ __pw_db_users | default({}) | combine({
+           item.item: (item.resources[0].data[__aap_password_rotate_db_config[item.item].k8s_username_field] | b64decode)
+         }) }}
+  loop: "{{ __pw_pg_secrets.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+  no_log: true
+
+- name: Display detected DB users
+  ansible.builtin.debug:
+    msg: "DB users: {{ __pw_db_users }}"
+
+# ── Internal DB: ALTER ROLE automatically ────────────────────────────
+- name: Find postgres pod (internal DB)
+  ansible.builtin.command:
+    cmd: >-
+      {{ aap_password_rotate_kubectl_binary }} -n {{ aap_password_rotate_namespace }}
+      get pods -l app.kubernetes.io/component=database
+      --field-selector=status.phase=Running
+      -o jsonpath={.items[0].metadata.name}
+  register: __pw_pg_pod
+  changed_when: false
+  failed_when: false
+  when: not aap_password_rotate_external_db
+
+- name: Set PG exec target
+  ansible.builtin.set_fact:
+    __pw_pg_exec_pod: "{{ __pw_pg_pod.stdout | default('') }}"
+  when: not aap_password_rotate_external_db
+
+- name: ALTER ROLE for component DB users (internal DB)
+  ansible.builtin.include_tasks: operator/alter_role.yml
+  loop: "{{ aap_password_rotate_components }}"
+  loop_control:
+    loop_var: __pw_component
+  when: not aap_password_rotate_external_db
+
+- name: ALTER postgres superuser (internal DB)
+  ansible.builtin.include_tasks: operator/alter_role_postgres.yml
+  when:
+    - not aap_password_rotate_external_db
+    - aap_password_rotate_include_postgres_admin | bool
+
+# ── External DB: pause for manual ALTER ROLE ─────────────────────────
+- name: External DB manual ALTER ROLE
+  ansible.builtin.include_tasks: external_db_pause.yml
+  when: aap_password_rotate_external_db
+
+# ── Patch K8s secrets ───────────────────────────────────────────────
+- name: Patch postgres-configuration secrets
+  ansible.builtin.command:
+    cmd: >-
+      {{ aap_password_rotate_kubectl_binary }} -n {{ aap_password_rotate_namespace }}
+      patch secret {{ __aap_password_rotate_db_config[item].k8s_secret }}
+      --type merge
+      -p '{"data":{"{{ __aap_password_rotate_db_config[item].k8s_secret_field }}":"{{ __pw_db_passwords[item] | b64encode }}"}}'
+  loop: "{{ aap_password_rotate_components }}"
+  no_log: true
+  changed_when: true
+
+# ── Rollout restart deployments ─────────────────────────────────────
+- name: Rollout restart component deployments
+  ansible.builtin.include_tasks: operator/rollout_restart.yml
+  loop: "{{ aap_password_rotate_components }}"
+  loop_control:
+    loop_var: __pw_component
+...

--- a/roles/aap_password_rotate/tasks/podman/alter_role.yml
+++ b/roles/aap_password_rotate/tasks/podman/alter_role.yml
@@ -1,0 +1,13 @@
+---
+# ALTER ROLE for a single component's DB user on podman deployments (internal DB).
+# Called in a loop from rotate_db_manual.yml.
+
+- name: "ALTER ROLE {{ __aap_password_rotate_db_config[__pw_component].db_user_podman }} ({{ __pw_component }})"
+  ansible.builtin.command:
+    cmd: >-
+      podman exec {{ aap_password_rotate_pg_container }}
+      psql -U postgres -c
+      "ALTER ROLE {{ __aap_password_rotate_db_config[__pw_component].db_user_podman }} WITH PASSWORD '{{ __pw_db_passwords[__pw_component] }}';"
+  no_log: true
+  changed_when: true
+...

--- a/roles/aap_password_rotate/tasks/podman/alter_role.yml
+++ b/roles/aap_password_rotate/tasks/podman/alter_role.yml
@@ -2,7 +2,7 @@
 # ALTER ROLE for a single component's DB user on podman deployments (internal DB).
 # Called in a loop from rotate_db_manual.yml.
 
-- name: "ALTER ROLE {{ __aap_password_rotate_db_config[__pw_component].db_user_podman }} ({{ __pw_component }})"
+- name: "ALTER ROLE for component - {{ __pw_component }}"
   ansible.builtin.command:
     cmd: >-
       podman exec {{ aap_password_rotate_pg_container }}

--- a/roles/aap_password_rotate/tasks/podman/alter_role_postgres.yml
+++ b/roles/aap_password_rotate/tasks/podman/alter_role_postgres.yml
@@ -1,0 +1,21 @@
+---
+# ALTER ROLE for the postgres superuser on podman deployments (internal DB).
+
+- name: ALTER ROLE postgres
+  ansible.builtin.command:
+    cmd: >-
+      podman exec {{ aap_password_rotate_pg_container }}
+      psql -U postgres -c "ALTER ROLE postgres WITH PASSWORD '{{ __pw_postgres_admin_password }}';"
+  no_log: true
+  changed_when: true
+
+- name: Verify new postgres password works
+  ansible.builtin.command:
+    cmd: >-
+      podman exec {{ aap_password_rotate_pg_container }}
+      psql -h localhost -U postgres -c "SELECT 1;"
+  environment:
+    PGPASSWORD: "{{ __pw_postgres_admin_password }}"
+  no_log: true
+  changed_when: false
+...

--- a/roles/aap_password_rotate/tasks/podman/change_admin_password.yml
+++ b/roles/aap_password_rotate/tasks/podman/change_admin_password.yml
@@ -8,7 +8,7 @@
 #   - hub: pulpcore-manager reset-admin-password
 #   - eda: aap-eda-manage update_password --username admin --password <pw>
 
-- name: "Change {{ __pw_component }} admin password"
+- name: "Change admin password - {{ __pw_component }}"
   when: __pw_component == 'eda'
   ansible.builtin.command:
     cmd: >-
@@ -20,7 +20,7 @@
   no_log: true
   changed_when: true
 
-- name: "Change {{ __pw_component }} admin password (Django shell)"
+- name: "Change admin password (Django shell) - {{ __pw_component }}"
   when: __pw_component in ['controller', 'gateway']
   ansible.builtin.shell:
     cmd: >-
@@ -36,7 +36,7 @@
   no_log: true
   changed_when: true
 
-- name: "Change {{ __pw_component }} admin password (pulpcore)"
+- name: "Change admin password (pulpcore) - {{ __pw_component }}"
   when: __pw_component == 'hub'
   ansible.builtin.shell:
     cmd: >-

--- a/roles/aap_password_rotate/tasks/podman/change_admin_password.yml
+++ b/roles/aap_password_rotate/tasks/podman/change_admin_password.yml
@@ -1,0 +1,50 @@
+---
+# Change admin password for a single component on podman.
+# Called in a loop from rotate_admin.yml.
+#
+# Each component uses a different management command:
+#   - gateway: aap-gateway-manage changepassword admin
+#   - controller: awx-manage changepassword admin
+#   - hub: pulpcore-manager reset-admin-password
+#   - eda: aap-eda-manage update_password --username admin --password <pw>
+
+- name: "Change {{ __pw_component }} admin password"
+  when: __pw_component == 'eda'
+  ansible.builtin.command:
+    cmd: >-
+      podman exec {{ __aap_password_rotate_admin_config[__pw_component].podman_container }}
+      {{ __aap_password_rotate_admin_config[__pw_component].manage_cmd }}
+      {{ __aap_password_rotate_admin_config[__pw_component].change_cmd }}
+      {{ __aap_password_rotate_admin_config[__pw_component].change_args }}
+      {{ __pw_admin_passwords[__pw_component] }}
+  no_log: true
+  changed_when: true
+
+- name: "Change {{ __pw_component }} admin password (Django shell)"
+  when: __pw_component in ['controller', 'gateway']
+  ansible.builtin.shell:
+    cmd: >-
+      podman exec {{ __aap_password_rotate_admin_config[__pw_component].podman_container }}
+      {{ __aap_password_rotate_admin_config[__pw_component].manage_cmd }} shell -c
+      "from django.contrib.auth import get_user_model;
+      User = get_user_model();
+      u = User.objects.get(username='admin');
+      u.set_password('{{ __pw_admin_passwords[__pw_component] }}');
+      u.save();
+      print('password changed')"
+    executable: /bin/bash
+  no_log: true
+  changed_when: true
+
+- name: "Change {{ __pw_component }} admin password (pulpcore)"
+  when: __pw_component == 'hub'
+  ansible.builtin.shell:
+    cmd: >-
+      podman exec {{ __aap_password_rotate_admin_config[__pw_component].podman_container }}
+      {{ __aap_password_rotate_admin_config[__pw_component].manage_cmd }}
+      {{ __aap_password_rotate_admin_config[__pw_component].change_cmd }}
+      --password '{{ __pw_admin_passwords[__pw_component] }}'
+    executable: /bin/bash
+  no_log: true
+  changed_when: true
+...

--- a/roles/aap_password_rotate/tasks/podman/rotate_admin.yml
+++ b/roles/aap_password_rotate/tasks/podman/rotate_admin.yml
@@ -1,0 +1,21 @@
+---
+# Rotate admin user passwords on podman deployments.
+# Each component has its own management command for changing the admin password.
+# Gateway is the primary auth source in AAP 2.5+; component admin passwords
+# are used for internal service communication.
+
+- name: Rotate admin passwords
+  ansible.builtin.include_tasks: podman/change_admin_password.yml
+  loop: "{{ aap_password_rotate_components }}"
+  loop_control:
+    loop_var: __pw_component
+
+- name: Update admin passwords in inventory
+  ansible.builtin.lineinfile:
+    path: "{{ aap_password_rotate_installer_inventory }}"
+    regexp: "^{{ __aap_password_rotate_admin_config[item].inventory_var }}="
+    line: "{{ __aap_password_rotate_admin_config[item].inventory_var }}={{ __pw_admin_passwords[item] }}"
+  loop: "{{ aap_password_rotate_components }}"
+  no_log: true
+  when: aap_password_rotate_installer_inventory | length > 0
+...

--- a/roles/aap_password_rotate/tasks/podman/rotate_db.yml
+++ b/roles/aap_password_rotate/tasks/podman/rotate_db.yml
@@ -1,0 +1,111 @@
+---
+# Podman DB password rotation via the containerised installer.
+#
+# Per KCS 7145426, the installer handles:
+#   1. ALTER ROLE for component users (awx, pulp, eda, gateway)
+#   2. Updating podman secrets
+#   3. Restarting containers
+#
+# The postgres superuser requires manual ALTER ROLE first because the
+# installer needs the current password to connect.
+
+- name: Read current inventory
+  ansible.builtin.slurp:
+    src: "{{ aap_password_rotate_installer_inventory }}"
+  register: __pw_inventory_raw
+  no_log: true
+
+- name: Backup current inventory
+  ansible.builtin.copy:
+    src: "{{ aap_password_rotate_installer_inventory }}"
+    dest: "{{ aap_password_rotate_backup_dir }}/inventory.backup"
+    mode: "0600"
+    remote_src: true
+
+# ── ALTER ROLE postgres (if included) ────────────────────────────────
+# Must happen BEFORE the installer re-run because the installer uses
+# the postgres password to connect and change component passwords.
+- name: ALTER postgres superuser password
+  when: aap_password_rotate_include_postgres_admin | bool
+  block:
+    - name: Check if PostgreSQL runs in a container
+      ansible.builtin.command:
+        cmd: "podman container exists {{ aap_password_rotate_pg_container }}"
+      register: __pw_pg_container_exists
+      changed_when: false
+      failed_when: false
+
+    - name: ALTER ROLE postgres via container
+      ansible.builtin.command:
+        cmd: >-
+          podman exec {{ aap_password_rotate_pg_container }}
+          psql -U postgres -c "ALTER ROLE postgres WITH PASSWORD '{{ __pw_postgres_admin_password }}';"
+      no_log: true
+      changed_when: true
+      when: __pw_pg_container_exists.rc == 0
+
+    - name: ALTER ROLE postgres via host psql (external/systemd PG)
+      ansible.builtin.command:
+        cmd: >-
+          sudo -u postgres psql -c "ALTER ROLE postgres WITH PASSWORD '{{ __pw_postgres_admin_password }}';"
+      no_log: true
+      changed_when: true
+      when: __pw_pg_container_exists.rc != 0
+
+    - name: Verify new postgres password works (container)
+      ansible.builtin.command:
+        cmd: >-
+          podman exec {{ aap_password_rotate_pg_container }}
+          psql -h localhost -U postgres -c "SELECT 1;"
+      environment:
+        PGPASSWORD: "{{ __pw_postgres_admin_password }}"
+      no_log: true
+      changed_when: false
+      when: __pw_pg_container_exists.rc == 0
+
+    - name: Verify new postgres password works (host)
+      ansible.builtin.command:
+        cmd: "psql -h localhost -U postgres -c 'SELECT 1;'"
+      environment:
+        PGPASSWORD: "{{ __pw_postgres_admin_password }}"
+      no_log: true
+      changed_when: false
+      when: __pw_pg_container_exists.rc != 0
+
+# ── Update inventory with new passwords ──────────────────────────────
+- name: Update component DB passwords in inventory
+  ansible.builtin.lineinfile:
+    path: "{{ aap_password_rotate_installer_inventory }}"
+    regexp: "^{{ __aap_password_rotate_db_config[item].inventory_var }}="
+    line: "{{ __aap_password_rotate_db_config[item].inventory_var }}={{ __pw_db_passwords[item] }}"
+  loop: "{{ aap_password_rotate_components }}"
+  no_log: true
+
+- name: Update postgresql_admin_password in inventory
+  ansible.builtin.lineinfile:
+    path: "{{ aap_password_rotate_installer_inventory }}"
+    regexp: "^postgresql_admin_password="
+    line: "postgresql_admin_password={{ __pw_postgres_admin_password }}"
+  when: aap_password_rotate_include_postgres_admin | bool
+  no_log: true
+
+# ── Re-run the installer ────────────────────────────────────────────
+- name: Re-run containerised installer
+  ansible.builtin.command:
+    cmd: "ansible-playbook -i {{ aap_password_rotate_installer_inventory }} ansible.containerized_installer.install"
+    chdir: "{{ aap_password_rotate_installer_dir }}"
+  register: __pw_installer_result
+  changed_when: true
+
+- name: Display installer result summary
+  ansible.builtin.debug:
+    msg: "{{ __pw_installer_result.stdout_lines[-5:] }}"
+
+- name: Verify installer succeeded
+  ansible.builtin.assert:
+    that: __pw_installer_result.rc == 0
+    fail_msg: >-
+      Installer re-run failed with rc={{ __pw_installer_result.rc }}.
+      Check the installer output for details.
+    success_msg: "Installer re-run completed successfully"
+...

--- a/roles/aap_password_rotate/tasks/podman/rotate_db_manual.yml
+++ b/roles/aap_password_rotate/tasks/podman/rotate_db_manual.yml
@@ -1,0 +1,63 @@
+---
+# Manual podman DB password rotation (without re-running the installer).
+# For each component: ALTER ROLE, update podman secret, update config
+# file inside containers, restart containers.
+#
+# Use this path when re-running the installer is not desirable
+# (e.g., external DB where the installer cannot reach PostgreSQL).
+
+# ── Build DB user map (podman uses hardcoded names) ───────────────────
+- name: Build DB user map from config
+  ansible.builtin.set_fact:
+    __pw_db_users: >-
+      {{ __pw_db_users | default({}) | combine({
+           item: __aap_password_rotate_db_config[item].db_user_podman
+         }) }}
+  loop: "{{ aap_password_rotate_components }}"
+
+# ── Internal DB: ALTER ROLE automatically ─────────────────────────────
+- name: ALTER ROLE for component DB users (internal DB)
+  ansible.builtin.include_tasks: podman/alter_role.yml
+  loop: "{{ aap_password_rotate_components }}"
+  loop_control:
+    loop_var: __pw_component
+  when: not aap_password_rotate_external_db
+
+- name: ALTER postgres superuser (internal DB)
+  ansible.builtin.include_tasks: podman/alter_role_postgres.yml
+  when:
+    - not aap_password_rotate_external_db
+    - aap_password_rotate_include_postgres_admin | bool
+
+# ── External DB: pause for manual ALTER ROLE ──────────────────────────
+- name: External DB manual ALTER ROLE
+  ansible.builtin.include_tasks: external_db_pause.yml
+  when: aap_password_rotate_external_db
+
+# ── Update podman secrets and config files ────────────────────────────
+- name: Update podman secrets and restart
+  ansible.builtin.include_tasks: podman/update_secret_and_restart.yml
+  loop: "{{ aap_password_rotate_components }}"
+  loop_control:
+    loop_var: __pw_component
+
+# ── Update inventory file ─────────────────────────────────────────────
+- name: Update component DB passwords in inventory
+  ansible.builtin.lineinfile:
+    path: "{{ aap_password_rotate_installer_inventory }}"
+    regexp: "^{{ __aap_password_rotate_db_config[item].inventory_var }}="
+    line: "{{ __aap_password_rotate_db_config[item].inventory_var }}={{ __pw_db_passwords[item] }}"
+  loop: "{{ aap_password_rotate_components }}"
+  no_log: true
+  when: aap_password_rotate_installer_inventory | length > 0
+
+- name: Update postgresql_admin_password in inventory
+  ansible.builtin.lineinfile:
+    path: "{{ aap_password_rotate_installer_inventory }}"
+    regexp: "^postgresql_admin_password="
+    line: "postgresql_admin_password={{ __pw_postgres_admin_password }}"
+  when:
+    - aap_password_rotate_include_postgres_admin | bool
+    - aap_password_rotate_installer_inventory | length > 0
+  no_log: true
+...

--- a/roles/aap_password_rotate/tasks/podman/update_secret_and_restart.yml
+++ b/roles/aap_password_rotate/tasks/podman/update_secret_and_restart.yml
@@ -1,0 +1,46 @@
+---
+# Update the podman secret and restart containers for a single component.
+# Called in a loop from rotate_db_manual.yml.
+#
+# The podman secret stores the DB password. After updating it, we also
+# need to restart the containers so they pick up the new value.
+
+- name: "Read current podman secret for {{ __pw_component }}"
+  ansible.builtin.command:
+    cmd: "podman secret inspect --showsecret {{ __aap_password_rotate_db_config[__pw_component].inventory_var }} --format {% raw %}'{{ .SecretData }}'{% endraw %}"
+  register: __pw_current_secret
+  changed_when: false
+  failed_when: false
+  no_log: true
+
+- name: "Remove old podman secret for {{ __pw_component }}"
+  ansible.builtin.command:
+    cmd: "podman secret rm {{ __aap_password_rotate_db_config[__pw_component].inventory_var }}"
+  changed_when: true
+  failed_when: false
+  when: __pw_current_secret.rc == 0
+
+- name: "Create new podman secret for {{ __pw_component }}"
+  ansible.builtin.shell:
+    cmd: "echo -n '{{ __pw_db_passwords[__pw_component] }}' | podman secret create {{ __aap_password_rotate_db_config[__pw_component].inventory_var }} -"
+    executable: /bin/bash
+  no_log: true
+  changed_when: true
+
+- name: "Stop {{ __pw_component }} containers"
+  ansible.builtin.command:
+    cmd: "podman stop {{ item }}"
+  loop: "{{ __aap_password_rotate_podman_containers[__pw_component] }}"
+  changed_when: true
+  failed_when: false
+
+- name: "Start {{ __pw_component }} containers"
+  ansible.builtin.command:
+    cmd: "podman start {{ item }}"
+  loop: "{{ __aap_password_rotate_podman_containers[__pw_component] }}"
+  changed_when: true
+
+- name: "Wait for {{ __pw_component }} to be ready"
+  ansible.builtin.pause:
+    seconds: 10
+...

--- a/roles/aap_password_rotate/tasks/podman/update_secret_and_restart.yml
+++ b/roles/aap_password_rotate/tasks/podman/update_secret_and_restart.yml
@@ -20,27 +20,27 @@
   failed_when: false
   when: __pw_current_secret.rc == 0
 
-- name: "Create new podman secret for {{ __pw_component }}"
+- name: "Create new podman secret - {{ __pw_component }}"
   ansible.builtin.shell:
-    cmd: "echo -n '{{ __pw_db_passwords[__pw_component] }}' | podman secret create {{ __aap_password_rotate_db_config[__pw_component].inventory_var }} -"
+    cmd: "set -o pipefail && echo -n '{{ __pw_db_passwords[__pw_component] }}' | podman secret create {{ __aap_password_rotate_db_config[__pw_component].inventory_var }} -"
     executable: /bin/bash
   no_log: true
   changed_when: true
 
-- name: "Stop {{ __pw_component }} containers"
+- name: "Stop containers - {{ __pw_component }}"
   ansible.builtin.command:
     cmd: "podman stop {{ item }}"
   loop: "{{ __aap_password_rotate_podman_containers[__pw_component] }}"
   changed_when: true
   failed_when: false
 
-- name: "Start {{ __pw_component }} containers"
+- name: "Start containers - {{ __pw_component }}"
   ansible.builtin.command:
     cmd: "podman start {{ item }}"
   loop: "{{ __aap_password_rotate_podman_containers[__pw_component] }}"
   changed_when: true
 
-- name: "Wait for {{ __pw_component }} to be ready"
+- name: "Wait for ready state - {{ __pw_component }}"
   ansible.builtin.pause:
     seconds: 10
 ...

--- a/roles/aap_password_rotate/tasks/preflight.yml
+++ b/roles/aap_password_rotate/tasks/preflight.yml
@@ -93,7 +93,7 @@
       block:
         - name: Find installer directory
           ansible.builtin.shell:
-            cmd: "ls -d /tmp/ansible-automation-platform-containerized-setup-*/ /opt/aap-installer/ /home/*/aap-installer/ 2>/dev/null | head -1 | tr -d '\\n'"
+            cmd: "set -o pipefail && ls -d /tmp/ansible-automation-platform-containerized-setup-*/ /opt/aap-installer/ /home/*/aap-installer/ 2>/dev/null | head -1 | tr -d '\\n'"
             executable: /bin/bash
           register: __pw_installer_dir
           changed_when: false

--- a/roles/aap_password_rotate/tasks/preflight.yml
+++ b/roles/aap_password_rotate/tasks/preflight.yml
@@ -1,0 +1,152 @@
+---
+- name: Validate scope
+  ansible.builtin.assert:
+    that:
+      - aap_password_rotate_scope | length > 0
+      - aap_password_rotate_scope | difference(['db', 'admin']) | length == 0
+    fail_msg: "aap_password_rotate_scope must contain 'db', 'admin', or both. Got: {{ aap_password_rotate_scope }}"
+
+- name: Validate components
+  ansible.builtin.assert:
+    that:
+      - aap_password_rotate_components | length > 0
+      - aap_password_rotate_components | difference(['controller', 'hub', 'eda', 'gateway']) | length == 0
+    fail_msg: "Invalid components: {{ aap_password_rotate_components }}"
+
+# ── Deployment type detection ────────────────────────────────────────
+- name: Auto-detect deployment type (podman)
+  ansible.builtin.command:
+    cmd: podman ps --format "{{ '{{' }}.Names{{ '}}' }}" --filter name=automation-
+  register: __pw_podman_check
+  changed_when: false
+  failed_when: false
+  when: aap_password_rotate_deployment_type == ""
+
+- name: Auto-detect deployment type (operator)
+  ansible.builtin.command:
+    cmd: "{{ aap_password_rotate_kubectl_binary | default('kubectl', true) }} get aap --all-namespaces --no-headers"
+  register: __pw_k8s_check
+  changed_when: false
+  failed_when: false
+  when:
+    - aap_password_rotate_deployment_type == ""
+    - __pw_podman_check.rc | default(1) != 0 or __pw_podman_check.stdout | default('') | length == 0
+
+- name: Set deployment type
+  ansible.builtin.set_fact:
+    aap_password_rotate_deployment_type: >-
+      {{ 'podman' if (__pw_podman_check.rc | default(1) == 0 and __pw_podman_check.stdout | default('') | length > 0)
+         else ('operator' if (__pw_k8s_check.rc | default(1) == 0 and __pw_k8s_check.stdout | default('') | length > 0)
+         else '') }}
+  when: aap_password_rotate_deployment_type == ""
+
+- name: Fail if deployment type not detected
+  ansible.builtin.assert:
+    that: aap_password_rotate_deployment_type in ['podman', 'operator']
+    fail_msg: >-
+      Could not auto-detect deployment type. Set aap_password_rotate_deployment_type
+      to 'podman' or 'operator'.
+
+- name: Display detected deployment type
+  ansible.builtin.debug:
+    msg: "Deployment type: {{ aap_password_rotate_deployment_type }}"
+
+# ── kubectl/oc detection (operator) ─────────────────────────────────
+- name: Detect kubectl binary
+  when:
+    - aap_password_rotate_deployment_type == 'operator'
+    - aap_password_rotate_kubectl_binary == ""
+  block:
+    - name: Check for oc
+      ansible.builtin.command:
+        cmd: which oc
+      register: __pw_oc_check
+      changed_when: false
+      failed_when: false
+
+    - name: Check for kubectl
+      ansible.builtin.command:
+        cmd: which kubectl
+      register: __pw_kubectl_check
+      changed_when: false
+      failed_when: false
+      when: __pw_oc_check.rc != 0
+
+    - name: Set kubectl binary
+      ansible.builtin.set_fact:
+        aap_password_rotate_kubectl_binary: "{{ __pw_oc_check.stdout if __pw_oc_check.rc == 0 else __pw_kubectl_check.stdout }}"
+
+    - name: Fail if no kubectl found
+      ansible.builtin.assert:
+        that: aap_password_rotate_kubectl_binary | length > 0
+        fail_msg: "Neither oc nor kubectl found. Install one or set aap_password_rotate_kubectl_binary."
+
+# ── Podman-specific preflight ───────────────────────────────────────
+- name: Podman preflight
+  when:
+    - aap_password_rotate_deployment_type == 'podman'
+    - "'db' in aap_password_rotate_scope"
+    - aap_password_rotate_podman_use_installer | bool
+  block:
+    - name: Auto-detect installer directory
+      when: aap_password_rotate_installer_dir == ""
+      block:
+        - name: Find installer directory
+          ansible.builtin.shell:
+            cmd: "ls -d /tmp/ansible-automation-platform-containerized-setup-*/ /opt/aap-installer/ /home/*/aap-installer/ 2>/dev/null | head -1 | tr -d '\\n'"
+            executable: /bin/bash
+          register: __pw_installer_dir
+          changed_when: false
+          failed_when: false
+
+        - name: Set installer directory
+          ansible.builtin.set_fact:
+            aap_password_rotate_installer_dir: "{{ __pw_installer_dir.stdout }}"
+          when: __pw_installer_dir.stdout | length > 0
+
+    - name: Fail if installer directory not found
+      ansible.builtin.assert:
+        that: aap_password_rotate_installer_dir | length > 0
+        fail_msg: >-
+          Installer directory not found. Set aap_password_rotate_installer_dir
+          to the path of the AAP containerised installer.
+
+    - name: Auto-detect inventory path
+      ansible.builtin.set_fact:
+        aap_password_rotate_installer_inventory: "{{ aap_password_rotate_installer_dir }}/inventory"
+      when: aap_password_rotate_installer_inventory == ""
+
+    - name: Verify inventory exists
+      ansible.builtin.stat:
+        path: "{{ aap_password_rotate_installer_inventory }}"
+      register: __pw_inv_stat
+
+    - name: Fail if inventory not found
+      ansible.builtin.assert:
+        that: __pw_inv_stat.stat.exists
+        fail_msg: "Inventory not found at {{ aap_password_rotate_installer_inventory }}"
+
+# ── Verify PostgreSQL is accessible ─────────────────────────────────
+# Only check the PG container when doing manual (non-installer) rotation
+# with an internal DB. When using the installer or external DB, PG is
+# validated by the installer itself or handled by the user/hook.
+- name: Verify PostgreSQL is running (podman container)
+  ansible.builtin.command:
+    cmd: "podman exec {{ aap_password_rotate_pg_container }} pg_isready"
+  register: __pw_pg_ready
+  changed_when: false
+  failed_when: __pw_pg_ready.rc != 0
+  when:
+    - aap_password_rotate_deployment_type == 'podman'
+    - "'db' in aap_password_rotate_scope"
+    - not aap_password_rotate_external_db
+    - not (aap_password_rotate_podman_use_installer | bool)
+
+- name: Preflight complete
+  ansible.builtin.debug:
+    msg: >-
+      Preflight OK.
+      Type: {{ aap_password_rotate_deployment_type }}.
+      Scope: {{ aap_password_rotate_scope | join(', ') }}.
+      Components: {{ aap_password_rotate_components | join(', ') }}.
+...

--- a/roles/aap_password_rotate/tasks/verify.yml
+++ b/roles/aap_password_rotate/tasks/verify.yml
@@ -1,0 +1,174 @@
+---
+# Post-rotation verification.
+# Checks that all component APIs respond and authentication works
+# with the new passwords.
+
+# ── Determine the API base URL ──────────────────────────────────────
+- name: Get Gateway URL (podman)
+  ansible.builtin.set_fact:
+    __pw_gateway_url: "https://localhost"
+  when: aap_password_rotate_deployment_type == 'podman'
+
+- name: Get Gateway route (operator)
+  when: aap_password_rotate_deployment_type == 'operator'
+  block:
+    - name: Read Gateway route
+      ansible.builtin.command:
+        cmd: >-
+          {{ aap_password_rotate_kubectl_binary }} -n {{ aap_password_rotate_namespace }}
+          get route {{ aap_password_rotate_cr_name }}
+          -o jsonpath={.spec.host}
+      register: __pw_gw_route
+      changed_when: false
+
+    - name: Set Gateway URL
+      ansible.builtin.set_fact:
+        __pw_gateway_url: "https://{{ __pw_gw_route.stdout }}"
+
+# ── Determine the admin password to use for verification ────────────
+- name: Set verification admin password
+  ansible.builtin.set_fact:
+    __pw_verify_admin_password: >-
+      {{ __pw_admin_passwords.gateway
+         if ('admin' in aap_password_rotate_scope and 'gateway' in aap_password_rotate_components)
+         else (aap_password_rotate_gateway_admin_password if aap_password_rotate_gateway_admin_password | length > 0
+         else '__SKIP_AUTH_CHECK__') }}
+  no_log: true
+
+# ── Gateway ping ────────────────────────────────────────────────────
+- name: Verify Gateway ping
+  ansible.builtin.uri:
+    url: "{{ __pw_gateway_url }}/api/gateway/v1/ping/"
+    validate_certs: false
+    status_code: [200]
+  register: __pw_gw_ping
+  retries: 30
+  delay: 10
+  until: __pw_gw_ping.status == 200
+
+# ── Admin auth check ────────────────────────────────────────────────
+- name: Verify admin authentication
+  ansible.builtin.uri:
+    url: "{{ __pw_gateway_url }}/api/gateway/v1/me/"
+    validate_certs: false
+    user: admin
+    password: "{{ __pw_verify_admin_password }}"
+    force_basic_auth: true
+    status_code: [200]
+  register: __pw_auth_check
+  retries: 10
+  delay: 15
+  until: __pw_auth_check.status == 200
+  no_log: true
+  when: __pw_verify_admin_password != '__SKIP_AUTH_CHECK__'
+
+# ── Controller API ─────────────────────────────────────────────────
+- name: Verify Controller API
+  ansible.builtin.uri:
+    url: "{{ __pw_gateway_url }}/api/controller/v2/ping/"
+    validate_certs: false
+    status_code: [200]
+  register: __pw_ctrl_ping
+  retries: 15
+  delay: 10
+  until: __pw_ctrl_ping.status == 200
+  when: "'controller' in aap_password_rotate_components"
+
+# ── Hub API ─────────────────────────────────────────────────────────
+- name: Verify Hub API
+  ansible.builtin.uri:
+    url: "{{ __pw_gateway_url }}/api/galaxy/pulp/api/v3/status/"
+    validate_certs: false
+    status_code: [200]
+  register: __pw_hub_ping
+  retries: 15
+  delay: 10
+  until: __pw_hub_ping.status == 200
+  when: "'hub' in aap_password_rotate_components"
+  ignore_errors: true
+
+# ── EDA API ─────────────────────────────────────────────────────────
+- name: Verify EDA API
+  ansible.builtin.uri:
+    url: "{{ __pw_gateway_url }}/api/eda/v1/users/me/"
+    validate_certs: false
+    user: admin
+    password: "{{ __pw_verify_admin_password }}"
+    force_basic_auth: true
+    status_code: [200]
+  register: __pw_eda_ping
+  retries: 15
+  delay: 10
+  until: __pw_eda_ping.status == 200
+  no_log: true
+  when:
+    - "'eda' in aap_password_rotate_components"
+    - __pw_verify_admin_password != '__SKIP_AUTH_CHECK__'
+  ignore_errors: true
+
+# ── DB connectivity check ──────────────────────────────────────────
+- name: Check if PostgreSQL container exists (verify)
+  ansible.builtin.command:
+    cmd: "podman container exists {{ aap_password_rotate_pg_container }}"
+  register: __pw_verify_pg_container
+  changed_when: false
+  failed_when: false
+  when:
+    - aap_password_rotate_deployment_type == 'podman'
+    - "'db' in aap_password_rotate_scope"
+    - not aap_password_rotate_external_db
+
+- name: Verify DB connectivity with new passwords (podman container)
+  ansible.builtin.command:
+    cmd: >-
+      podman exec {{ aap_password_rotate_pg_container }}
+      psql -h localhost
+      -U {{ __aap_password_rotate_db_config[item].db_user_podman }}
+      -d {{ __aap_password_rotate_db_config[item].db_name_podman }}
+      -c "SELECT 1;"
+  environment:
+    PGPASSWORD: "{{ __pw_db_passwords[item] }}"
+  loop: "{{ aap_password_rotate_components }}"
+  changed_when: false
+  no_log: true
+  when:
+    - aap_password_rotate_deployment_type == 'podman'
+    - "'db' in aap_password_rotate_scope"
+    - not aap_password_rotate_external_db
+    - __pw_verify_pg_container.rc | default(1) == 0
+
+- name: Verify DB connectivity with new passwords (host psql)
+  ansible.builtin.command:
+    cmd: >-
+      psql -h localhost
+      -U {{ __aap_password_rotate_db_config[item].db_user_podman }}
+      -d {{ __aap_password_rotate_db_config[item].db_name_podman }}
+      -c "SELECT 1;"
+  environment:
+    PGPASSWORD: "{{ __pw_db_passwords[item] }}"
+  loop: "{{ aap_password_rotate_components }}"
+  changed_when: false
+  no_log: true
+  when:
+    - aap_password_rotate_deployment_type == 'podman'
+    - "'db' in aap_password_rotate_scope"
+    - not aap_password_rotate_external_db
+    - __pw_verify_pg_container.rc | default(1) != 0
+
+# ── Summary ─────────────────────────────────────────────────────────
+- name: "RESULT"
+  ansible.builtin.debug:
+    msg: |
+      ═══════════════════════════════════════════
+      PASSWORD ROTATION: PASS
+      ═══════════════════════════════════════════
+      Gateway ping:    HTTP {{ __pw_gw_ping.status }}
+      Admin auth:      {{ 'HTTP ' ~ __pw_auth_check.status if __pw_verify_admin_password != '__SKIP_AUTH_CHECK__' else 'skipped' }}
+      Controller API:  {{ 'HTTP ' ~ __pw_ctrl_ping.status if 'controller' in aap_password_rotate_components else 'skipped' }}
+      Hub API:         {{ 'HTTP ' ~ (__pw_hub_ping.status | default('N/A')) if 'hub' in aap_password_rotate_components else 'skipped' }}
+      EDA API:         {{ 'HTTP ' ~ (__pw_eda_ping.status | default('N/A')) if 'eda' in aap_password_rotate_components else 'skipped' }}
+      Scope:           {{ aap_password_rotate_scope | join(', ') }}
+      Components:      {{ aap_password_rotate_components | join(', ') }}
+      Backup:          {{ aap_password_rotate_backup_dir }}/aap_passwords.bak
+      ═══════════════════════════════════════════
+...

--- a/roles/aap_password_rotate/vars/main.yml
+++ b/roles/aap_password_rotate/vars/main.yml
@@ -1,0 +1,171 @@
+---
+# Per-component configuration map for password rotation.
+# Maps component names to their DB users, config paths, secrets, and
+# management commands for both podman and operator deployments.
+
+__aap_password_rotate_db_config:
+  controller:
+    db_user_podman: "awx"
+    db_name_podman: "awx"
+    inventory_var: "controller_pg_password"
+    podman_container: "{{ aap_password_rotate_controller_container }}"
+    config_file: "/etc/tower/conf.d/postgres.py"
+    config_format: "python"
+    k8s_secret: "{{ aap_password_rotate_cr_name }}-controller-postgres-configuration"
+    k8s_secret_field: "password"
+    k8s_username_field: "username"
+    k8s_database_field: "database"
+    k8s_deployment_label: "app.kubernetes.io/component=automationcontroller"
+
+  gateway:
+    db_user_podman: "gateway"
+    db_name_podman: "gateway"
+    inventory_var: "gateway_pg_password"
+    podman_container: "{{ aap_password_rotate_gateway_container }}"
+    config_file: "/etc/ansible-automation-platform/gateway/settings.py"
+    config_format: "python"
+    k8s_secret: "{{ aap_password_rotate_cr_name }}-gateway-postgres-configuration"
+    k8s_secret_field: "password"
+    k8s_username_field: "username"
+    k8s_database_field: "database"
+    k8s_deployment_label: "app.kubernetes.io/component=aap-gateway"
+
+  eda:
+    db_user_podman: "eda"
+    db_name_podman: "eda"
+    inventory_var: "eda_pg_password"
+    podman_container: "{{ aap_password_rotate_eda_container }}"
+    config_file: "/etc/ansible-automation-platform/eda/environment"
+    config_format: "env"
+    k8s_secret: "{{ aap_password_rotate_cr_name }}-eda-postgres-configuration"
+    k8s_secret_field: "password"
+    k8s_username_field: "username"
+    k8s_database_field: "database"
+    k8s_deployment_label: "app.kubernetes.io/component=eda-api"
+
+  hub:
+    db_user_podman: "pulp"
+    db_name_podman: "pulp"
+    inventory_var: "hub_pg_password"
+    podman_container: "{{ aap_password_rotate_hub_container }}"
+    config_file: "/etc/pulp/settings.py"
+    config_format: "python"
+    k8s_secret: "{{ aap_password_rotate_cr_name }}-hub-postgres-configuration"
+    k8s_secret_field: "password"
+    k8s_username_field: "username"
+    k8s_database_field: "database"
+    k8s_deployment_label: "app.kubernetes.io/component=api,app.kubernetes.io/part-of=automationhub"
+
+# Admin password management commands per component.
+__aap_password_rotate_admin_config:
+  gateway:
+    manage_cmd: "aap-gateway-manage"
+    change_cmd: "changepassword"
+    change_args: "admin"
+    podman_container: "{{ aap_password_rotate_gateway_container }}"
+    k8s_secret: "{{ aap_password_rotate_cr_name }}-admin-password"
+    k8s_secret_field: "password"
+    k8s_exec_deployment: "{{ aap_password_rotate_cr_name }}-gateway"
+    k8s_exec_container: "api"
+    inventory_var: "gateway_admin_password"
+    password_env_var: "GATEWAY_ADMIN_PASSWORD"
+
+  controller:
+    manage_cmd: "awx-manage"
+    change_cmd: "changepassword"
+    change_args: "admin"
+    podman_container: "{{ aap_password_rotate_controller_container }}"
+    k8s_secret: "{{ aap_password_rotate_cr_name }}-controller-admin-password"
+    k8s_secret_field: "password"
+    k8s_exec_deployment: "{{ aap_password_rotate_cr_name }}-controller-task"
+    k8s_exec_container: "{{ aap_password_rotate_cr_name }}-controller-task"
+    inventory_var: "controller_admin_password"
+    password_env_var: "DJANGO_SUPERUSER_PASSWORD"
+
+  hub:
+    manage_cmd: "pulpcore-manager"
+    change_cmd: "reset-admin-password"
+    change_args: ""
+    podman_container: "{{ aap_password_rotate_hub_container }}"
+    k8s_secret: "{{ aap_password_rotate_cr_name }}-hub-admin-password"
+    k8s_secret_field: "password"
+    k8s_exec_deployment: "{{ aap_password_rotate_cr_name }}-hub-api"
+    k8s_exec_container: "api"
+    inventory_var: "hub_admin_password"
+    password_env_var: "PULP_DEFAULT_ADMIN_PASSWORD"
+
+  eda:
+    manage_cmd: "aap-eda-manage"
+    change_cmd: "update_password"
+    change_args: "--username admin --password"
+    podman_container: "{{ aap_password_rotate_eda_container }}"
+    k8s_secret: "{{ aap_password_rotate_cr_name }}-eda-admin-password"
+    k8s_secret_field: "password"
+    k8s_exec_deployment: "{{ aap_password_rotate_cr_name }}-eda-api"
+    k8s_exec_container: "eda-api"
+    inventory_var: "eda_admin_password"
+    password_env_var: "EDA_ADMIN_PASSWORD"
+
+# PostgreSQL container name (podman) or pod label (operator)
+__aap_password_rotate_pg_container: "{{ aap_password_rotate_pg_container }}"
+
+# All podman containers per component that need restarting after DB password changes
+# (only used when aap_password_rotate_podman_use_installer is false)
+__aap_password_rotate_podman_containers:
+  controller:
+    - "automation-controller-task"
+    - "automation-controller-web"
+  gateway:
+    - "automation-gateway"
+  eda:
+    - "automation-eda-api"
+    - "automation-eda-daphne"
+    - "automation-eda-web"
+    - "automation-eda-worker-1"
+    - "automation-eda-worker-2"
+    - "automation-eda-activation-worker-1"
+    - "automation-eda-activation-worker-2"
+  hub:
+    - "automation-hub-api"
+    - "automation-hub-content"
+    - "automation-hub-web"
+    - "automation-hub-worker-1"
+    - "automation-hub-worker-2"
+
+# Kubernetes deployments per component that need rollout restart
+__aap_password_rotate_k8s_deployments:
+  controller:
+    - "{{ aap_password_rotate_cr_name }}-controller-task"
+    - "{{ aap_password_rotate_cr_name }}-controller-web"
+  gateway:
+    - "{{ aap_password_rotate_cr_name }}-gateway"
+  eda:
+    - "{{ aap_password_rotate_cr_name }}-eda-api"
+    - "{{ aap_password_rotate_cr_name }}-eda-activation-worker"
+    - "{{ aap_password_rotate_cr_name }}-eda-default-worker"
+    - "{{ aap_password_rotate_cr_name }}-eda-event-stream"
+  hub:
+    - "{{ aap_password_rotate_cr_name }}-hub-api"
+    - "{{ aap_password_rotate_cr_name }}-hub-content"
+    - "{{ aap_password_rotate_cr_name }}-hub-worker"
+    - "{{ aap_password_rotate_cr_name }}-hub-web"
+
+# Kubernetes exec targets per component
+__aap_password_rotate_k8s_exec:
+  controller:
+    deployment: "{{ aap_password_rotate_cr_name }}-controller-task"
+    label_component: "automationcontroller"
+    container: "{{ aap_password_rotate_cr_name }}-controller-task"
+  gateway:
+    deployment: "{{ aap_password_rotate_cr_name }}-gateway"
+    label_component: "aap-gateway"
+    container: "api"
+  eda:
+    deployment: "{{ aap_password_rotate_cr_name }}-eda-api"
+    label_component: "eda-api"
+    container: "eda-api"
+  hub:
+    deployment: "{{ aap_password_rotate_cr_name }}-hub-api"
+    label_component: "api,app.kubernetes.io/part-of=automationhub"
+    container: "api"
+...


### PR DESCRIPTION
## Summary

- Adds `aap_password_rotate` role to rotate PostgreSQL database passwords and admin user passwords across all AAP 2.7 components (controller, gateway, hub, EDA)
- Supports both **Podman** (via installer re-run per KCS 7145426) and **Operator** (via K8s secret patching and rollout restarts) deployment types
- Handles internal and external databases, with a hook mechanism (`aap_password_rotate_external_db_tasks`) for user-provided custom password change logic on external DBs

## Features

- **Scope control**: rotate DB passwords, admin passwords, or both (`aap_password_rotate_scope`)
- **Selective components**: rotate all or specific components (`aap_password_rotate_components`)
- **Postgres superuser rotation**: optional `aap_password_rotate_include_postgres_admin`
- **External DB support**: three modes (hook tasks, no-pause, interactive pause with generated SQL)
- **Backup**: saves all new passwords and inventory backup before any changes
- **Verification**: comprehensive post-rotation checks (API health, DB connectivity, admin auth)
- **Dry run**: preview what would change without making modifications

## Deployment type details

### Podman (containerized installer)
Following the procedure from KCS 7145426:
1. ALTER ROLE postgres superuser (installer does not handle this)
2. Update installer inventory with new `*_pg_password` values
3. Re-run the containerized installer (handles ALTER ROLE for component users, updates podman secrets, restarts containers)
4. Rotate admin passwords via Django shell / pulpcore manage commands

### Operator (OpenShift)
1. ALTER ROLE via `oc exec` into the postgres pod
2. Patch K8s Secrets with new passwords
3. Rollout restart deployments to pick up new secrets
4. Rotate admin passwords via `oc exec` into component pods

## Test plan

- [x] E2E tested on OCP 4.17 Operator deployment (internal DB, full scope rotation)
- [x] E2E tested on OCP 4.17 Operator deployment (external DB mode with no_pause)
- [x] E2E tested on OCP 4.17 Operator deployment (selective component/scope rotation)
- [x] E2E tested on RHEL 9.7 Podman deployment with systemd PostgreSQL 16 (full scope rotation)
- [x] Verified DB passwords changed for all components (controller, gateway, eda, hub)
- [x] Verified admin passwords rotated and old passwords rejected
- [x] Verified test user authentication preserved after rotation
- [x] Verified stored credentials remain accessible after rotation
- [x] Verified all component APIs healthy post-rotation

## Related

- Companion to `aap_secret_rotate` role (PR #380) which handles SECRET_KEY rotation
- References KCS 7145426 (How to rotate PostgreSQL database passwords in AAP 2.7 Containerized)


Made with [Cursor](https://cursor.com)